### PR TITLE
Updated sizes in type definitions

### DIFF
--- a/ipfs-api/src/client.rs
+++ b/ipfs-api/src/client.rs
@@ -1712,7 +1712,7 @@ impl IpfsClient {
     pub fn ping(
         &self,
         peer: &str,
-        count: &Option<usize>,
+        count: &Option<i32>,
     ) -> AsyncStreamResponse<response::PingResponse> {
         self.request_stream_json(&request::Ping { peer, count }, None)
     }

--- a/ipfs-api/src/request/ping.rs
+++ b/ipfs-api/src/request/ping.rs
@@ -14,7 +14,7 @@ pub struct Ping<'a, 'b> {
     #[serde(rename = "arg")]
     pub peer: &'a str,
 
-    pub count: &'b Option<usize>,
+    pub count: &'b Option<i32>,
 }
 
 impl<'a, 'b> ApiRequest for Ping<'a, 'b> {

--- a/ipfs-api/src/response/bitswap.rs
+++ b/ipfs-api/src/response/bitswap.rs
@@ -23,7 +23,7 @@ pub struct BitswapLedgerResponse {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct BitswapStatResponse {
-    pub provide_buf_len: usize,
+    pub provide_buf_len: i32,
 
     #[serde(deserialize_with = "serde::deserialize_vec")]
     pub wantlist: Vec<String>,
@@ -31,11 +31,11 @@ pub struct BitswapStatResponse {
     #[serde(deserialize_with = "serde::deserialize_vec")]
     pub peers: Vec<String>,
 
-    pub blocks_received: usize,
+    pub blocks_received: u64,
     pub data_received: u64,
-    pub blocks_sent: usize,
+    pub blocks_sent: u64,
     pub data_sent: u64,
-    pub dup_blks_received: usize,
+    pub dup_blks_received: u64,
     pub dup_data_received: u64,
 }
 

--- a/ipfs-api/src/response/block.rs
+++ b/ipfs-api/src/response/block.rs
@@ -10,7 +10,7 @@
 #[serde(rename_all = "PascalCase")]
 pub struct BlockPutResponse {
     pub key: String,
-    pub size: usize,
+    pub size: u64,
 }
 
 
@@ -26,7 +26,7 @@ pub struct BlockRmResponse {
 #[serde(rename_all = "PascalCase")]
 pub struct BlockStatResponse {
     pub key: String,
-    pub size: usize,
+    pub size: u64,
 }
 
 

--- a/ipfs-api/src/response/files.rs
+++ b/ipfs-api/src/response/files.rs
@@ -20,9 +20,11 @@ pub type FilesFlushResponse = ();
 pub struct FilesEntry {
     pub name: String,
 
+    // This is a protocol buffer enum type defined in https://github.com/ipfs/go-ipfs/blob/master/unixfs/pb/unixfs.proto ...
+    // So it might be some other type than u64, but certainly shouldn't be *bigger* than u64.
     #[serde(rename = "Type")]
-    pub typ: isize,
-    pub size: i64,
+    pub typ: u64,
+    pub size: u64,
     pub hash: String,
 }
 
@@ -50,7 +52,7 @@ pub struct FilesStatResponse {
     pub hash: String,
     pub size: u64,
     pub cumulative_size: u64,
-    pub blocks: isize,
+    pub blocks: u64,
 
     #[serde(rename = "Type")]
     pub typ: String,

--- a/ipfs-api/src/response/object.rs
+++ b/ipfs-api/src/response/object.rs
@@ -17,7 +17,7 @@ pub type ObjectDataResponse = Vec<u8>;
 #[serde(rename_all = "PascalCase")]
 pub struct ObjectDiff {
     #[serde(rename = "Type")]
-    pub typ: isize,
+    pub typ: u64,
 
     pub path: String,
 
@@ -121,11 +121,11 @@ pub struct ObjectPutResponse {
 #[serde(rename_all = "PascalCase")]
 pub struct ObjectStatResponse {
     pub hash: String,
-    pub num_links: isize,
-    pub block_size: isize,
-    pub links_size: isize,
-    pub data_size: isize,
-    pub cumulative_size: isize,
+    pub num_links: u64,
+    pub block_size: u64,
+    pub links_size: u64,
+    pub data_size: u64,
+    pub cumulative_size: u64,
 }
 
 

--- a/ipfs-api/src/response/pin.rs
+++ b/ipfs-api/src/response/pin.rs
@@ -16,7 +16,7 @@ pub struct PinAddResponse {
     #[serde(deserialize_with = "serde::deserialize_vec")]
     pub pins: Vec<String>,
 
-    pub progress: Option<isize>,
+    pub progress: Option<i32>,
 }
 
 

--- a/ipfs-api/src/response/repo.rs
+++ b/ipfs-api/src/response/repo.rs
@@ -36,11 +36,13 @@ pub struct RepoStatResponse {
 }
 
 
+// Defined in go-ipfs:master core/commands/repo.go
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct RepoVerifyResponse {
     pub message: String,
-    pub progress: isize,
+    // Could technically be an i64 but this is probably safest?
+    pub progress: i32,
 }
 
 


### PR DESCRIPTION
Mostly from digging through the go code in various places.

Rust doesn't really like 'usize' and 'isize' much because they're  specifically the size of array indexes; more like C's `size_t` than `int`.  So it can be annoying to use them on different platforms or in cross-platform API's or suck.  Annoyingly, Go is the exact opposite in this regard, and just uses `int` everywhere without a care in the world...

Anyway.  Should address issue #7 