### PR TITLE
Remove unnecessary references from Option types

### DIFF
--- a/ipfs-api/Cargo.toml
+++ b/ipfs-api/Cargo.toml
@@ -5,7 +5,7 @@ authors                   = ["Ferris Tseng <ferristseng@fastmail.fm>"]
 documentation             = "https://docs.rs/ipfs-api"
 keywords                  = ["ipfs"]
 categories                = ["filesystem", "web-programming"]
-version                   = "0.4.0-alpha"
+version                   = "0.4.0"
 readme                    = "../README.md"
 license                   = "MIT OR Apache-2.0"
 

--- a/ipfs-api/examples/ping_peer.rs
+++ b/ipfs-api/examples/ping_peer.rs
@@ -37,7 +37,7 @@ fn main() {
     println!("discovered peer ({})", peer.peer);
     println!("");
     println!("streaming 10 pings...");
-    let req = client.ping(&peer.peer[..], &Some(10));
+    let req = client.ping(&peer.peer[..], Some(10));
 
     core.run(req.for_each(|ping| {
         println!("{:?}", ping);
@@ -47,7 +47,7 @@ fn main() {
     println!("");
     println!("gathering 15 pings...");
 
-    let req = client.ping(&peer.peer[..], &Some(15));
+    let req = client.ping(&peer.peer[..], Some(15));
     let pings: Vec<_> = core.run(req.collect()).expect("expected a valid response");
 
     for ping in pings.iter() {

--- a/ipfs-api/src/client.rs
+++ b/ipfs-api/src/client.rs
@@ -1063,13 +1063,13 @@ impl IpfsClient {
     /// # fn main() {
     /// let mut core = Core::new().unwrap();
     /// let client = IpfsClient::default(&core.handle());
-    /// let req = client.files_flush(&None);
-    /// let req = client.files_flush(&Some("/tmp"));
+    /// let req = client.files_flush(None);
+    /// let req = client.files_flush(Some("/tmp"));
     /// # }
     /// ```
     ///
     #[inline]
-    pub fn files_flush(&self, path: &Option<&str>) -> AsyncResponse<response::FilesFlushResponse> {
+    pub fn files_flush(&self, path: Option<&str>) -> AsyncResponse<response::FilesFlushResponse> {
         self.request_empty(&request::FilesFlush { path }, None)
     }
 
@@ -1085,13 +1085,13 @@ impl IpfsClient {
     /// # fn main() {
     /// let mut core = Core::new().unwrap();
     /// let client = IpfsClient::default(&core.handle());
-    /// let req = client.files_ls(&None);
-    /// let req = client.files_ls(&Some("/tmp"));
+    /// let req = client.files_ls(None);
+    /// let req = client.files_ls(Some("/tmp"));
     /// # }
     /// ```
     ///
     #[inline]
-    pub fn files_ls(&self, path: &Option<&str>) -> AsyncResponse<response::FilesLsResponse> {
+    pub fn files_ls(&self, path: Option<&str>) -> AsyncResponse<response::FilesLsResponse> {
         self.request(&request::FilesLs { path }, None)
     }
 
@@ -1286,14 +1286,14 @@ impl IpfsClient {
     /// # fn main() {
     /// let mut core = Core::new().unwrap();
     /// let client = IpfsClient::default(&core.handle());
-    /// let req = client.filestore_ls(&Some("QmYPP3BovR2m8UqCZxFbdXSit6SKgExxDkFAPLqiGsap4X"));
+    /// let req = client.filestore_ls(Some("QmYPP3BovR2m8UqCZxFbdXSit6SKgExxDkFAPLqiGsap4X"));
     /// # }
     /// ```
     ///
     #[inline]
     pub fn filestore_ls(
         &self,
-        cid: &Option<&str>,
+        cid: Option<&str>,
     ) -> AsyncStreamResponse<response::FilestoreLsResponse> {
         self.request_stream_json(&request::FilestoreLs { cid }, None)
     }
@@ -1310,14 +1310,14 @@ impl IpfsClient {
     /// # fn main() {
     /// let mut core = Core::new().unwrap();
     /// let client = IpfsClient::default(&core.handle());
-    /// let req = client.filestore_verify(&None);
+    /// let req = client.filestore_verify(None);
     /// # }
     /// ```
     ///
     #[inline]
     pub fn filestore_verify(
         &self,
-        cid: &Option<&str>,
+        cid: Option<&str>,
     ) -> AsyncStreamResponse<response::FilestoreVerifyResponse> {
         self.request_stream_json(&request::FilestoreVerify { cid }, None)
     }
@@ -1357,13 +1357,13 @@ impl IpfsClient {
     /// # fn main() {
     /// let mut core = Core::new().unwrap();
     /// let client = IpfsClient::default(&core.handle());
-    /// let req = client.id(&None);
-    /// let req = client.id(&Some("QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM"));
+    /// let req = client.id(None);
+    /// let req = client.id(Some("QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM"));
     /// # }
     /// ```
     ///
     #[inline]
-    pub fn id(&self, peer: &Option<&str>) -> AsyncResponse<response::IdResponse> {
+    pub fn id(&self, peer: Option<&str>) -> AsyncResponse<response::IdResponse> {
         self.request(&request::Id { peer }, None)
     }
 
@@ -1379,7 +1379,7 @@ impl IpfsClient {
     /// # fn main() {
     /// let mut core = Core::new().unwrap();
     /// let client = IpfsClient::default(&core.handle());
-    /// let req = client.key_gen("test", KeyType::Rsa, &Some(64));
+    /// let req = client.key_gen("test", KeyType::Rsa, Some(64));
     /// # }
     /// ```
     ///
@@ -1388,7 +1388,7 @@ impl IpfsClient {
         &self,
         name: &str,
         kind: request::KeyType,
-        size: &Option<i32>,
+        size: Option<i32>,
     ) -> AsyncResponse<response::KeyGenResponse> {
         self.request(&request::KeyGen { name, kind, size }, None)
     }
@@ -1503,13 +1503,13 @@ impl IpfsClient {
     /// # fn main() {
     /// let mut core = Core::new().unwrap();
     /// let client = IpfsClient::default(&core.handle());
-    /// let req = client.ls(&None);
-    /// let req = client.ls(&Some("/ipfs/QmVrLsEDn27sScp3k23sgZNefVTjSAL3wpgW1iWPi4MgoY"));
+    /// let req = client.ls(None);
+    /// let req = client.ls(Some("/ipfs/QmVrLsEDn27sScp3k23sgZNefVTjSAL3wpgW1iWPi4MgoY"));
     /// # }
     /// ```
     ///
     #[inline]
-    pub fn ls(&self, path: &Option<&str>) -> AsyncResponse<response::LsResponse> {
+    pub fn ls(&self, path: Option<&str>) -> AsyncResponse<response::LsResponse> {
         self.request(&request::Ls { path }, None)
     }
 
@@ -1648,19 +1648,19 @@ impl IpfsClient {
     /// # fn main() {
     /// let mut core = Core::new().unwrap();
     /// let client = IpfsClient::default(&core.handle());
-    /// let req = client.pin_ls(&None, &None);
+    /// let req = client.pin_ls(None, None);
     /// let req = client.pin_ls(
-    ///     &Some("/ipfs/QmVrLsEDn27sScp3k23sgZNefVTjSAL3wpgW1iWPi4MgoY"),
-    ///     &None);
-    /// let req = client.pin_ls(&None, &Some("direct"));
+    ///     Some("/ipfs/QmVrLsEDn27sScp3k23sgZNefVTjSAL3wpgW1iWPi4MgoY"),
+    ///     None);
+    /// let req = client.pin_ls(None, Some("direct"));
     /// # }
     /// ```
     ///
     #[inline]
     pub fn pin_ls(
         &self,
-        key: &Option<&str>,
-        typ: &Option<&str>,
+        key: Option<&str>,
+        typ: Option<&str>,
     ) -> AsyncResponse<response::PinLsResponse> {
         self.request(&request::PinLs { key, typ }, None)
     }
@@ -1703,8 +1703,8 @@ impl IpfsClient {
     /// # fn main() {
     /// let mut core = Core::new().unwrap();
     /// let client = IpfsClient::default(&core.handle());
-    /// let req = client.ping("QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64", &None);
-    /// let req = client.ping("QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64", &Some(15));
+    /// let req = client.ping("QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64", None);
+    /// let req = client.ping("QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64", Some(15));
     /// # }
     /// ```
     ///
@@ -1712,7 +1712,7 @@ impl IpfsClient {
     pub fn ping(
         &self,
         peer: &str,
-        count: &Option<i32>,
+        count: Option<i32>,
     ) -> AsyncStreamResponse<response::PingResponse> {
         self.request_stream_json(&request::Ping { peer, count }, None)
     }
@@ -1750,15 +1750,15 @@ impl IpfsClient {
     /// # fn main() {
     /// let mut core = Core::new().unwrap();
     /// let client = IpfsClient::default(&core.handle());
-    /// let req = client.pubsub_peers(&None);
-    /// let req = client.pubsub_peers(&Some("feed"));
+    /// let req = client.pubsub_peers(None);
+    /// let req = client.pubsub_peers(Some("feed"));
     /// # }
     /// ```
     ///
     #[inline]
     pub fn pubsub_peers(
         &self,
-        topic: &Option<&str>,
+        topic: Option<&str>,
     ) -> AsyncResponse<response::PubsubPeersResponse> {
         self.request(&request::PubsubPeers { topic }, None)
     }

--- a/ipfs-api/src/request/files.rs
+++ b/ipfs-api/src/request/files.rs
@@ -29,7 +29,7 @@ impl<'a> ApiRequest for FilesCp<'a> {
 #[derive(Serialize)]
 pub struct FilesFlush<'a> {
     #[serde(rename = "arg")]
-    pub path: &'a Option<&'a str>,
+    pub path: Option<&'a str>,
 }
 
 impl<'a> ApiRequest for FilesFlush<'a> {
@@ -43,7 +43,7 @@ impl<'a> ApiRequest for FilesFlush<'a> {
 #[derive(Serialize)]
 pub struct FilesLs<'a> {
     #[serde(rename = "arg")]
-    pub path: &'a Option<&'a str>,
+    pub path: Option<&'a str>,
 }
 
 impl<'a> ApiRequest for FilesLs<'a> {

--- a/ipfs-api/src/request/filestore.rs
+++ b/ipfs-api/src/request/filestore.rs
@@ -24,7 +24,7 @@ impl ApiRequest for FilestoreDups {
 #[derive(Serialize)]
 pub struct FilestoreLs<'a> {
     #[serde(rename = "arg")]
-    pub cid: &'a Option<&'a str>,
+    pub cid: Option<&'a str>,
 }
 
 impl<'a> ApiRequest for FilestoreLs<'a> {
@@ -38,7 +38,7 @@ impl<'a> ApiRequest for FilestoreLs<'a> {
 #[derive(Serialize)]
 pub struct FilestoreVerify<'a> {
     #[serde(rename = "arg")]
-    pub cid: &'a Option<&'a str>,
+    pub cid: Option<&'a str>,
 }
 
 impl<'a> ApiRequest for FilestoreVerify<'a> {

--- a/ipfs-api/src/request/id.rs
+++ b/ipfs-api/src/request/id.rs
@@ -12,7 +12,7 @@ use request::ApiRequest;
 #[derive(Serialize)]
 pub struct Id<'a> {
     #[serde(rename = "arg")]
-    pub peer: &'a Option<&'a str>,
+    pub peer: Option<&'a str>,
 }
 
 impl<'a> ApiRequest for Id<'a> {

--- a/ipfs-api/src/request/key.rs
+++ b/ipfs-api/src/request/key.rs
@@ -32,17 +32,17 @@ impl Serialize for KeyType {
 
 
 #[derive(Serialize)]
-pub struct KeyGen<'a, 'b> {
+pub struct KeyGen<'a> {
     #[serde(rename = "arg")]
     pub name: &'a str,
 
     #[serde(rename = "type")]
     pub kind: KeyType,
 
-    pub size: &'b Option<i32>,
+    pub size: Option<i32>,
 }
 
-impl<'a, 'b> ApiRequest for KeyGen<'a, 'b> {
+impl<'a> ApiRequest for KeyGen<'a> {
     #[inline]
     fn path() -> &'static str {
         "/key/gen"

--- a/ipfs-api/src/request/ls.rs
+++ b/ipfs-api/src/request/ls.rs
@@ -12,7 +12,7 @@ use request::ApiRequest;
 #[derive(Serialize)]
 pub struct Ls<'a> {
     #[serde(rename = "arg")]
-    pub path: &'a Option<&'a str>,
+    pub path: Option<&'a str>,
 }
 
 impl<'a> ApiRequest for Ls<'a> {
@@ -27,6 +27,6 @@ impl<'a> ApiRequest for Ls<'a> {
 mod tests {
     use super::Ls;
 
-    serialize_url_test!(test_serializes_0, Ls { path: &Some("test") }, "arg=test");
-    serialize_url_test!(test_serializes_1, Ls { path: &None }, "");
+    serialize_url_test!(test_serializes_0, Ls { path: Some("test") }, "arg=test");
+    serialize_url_test!(test_serializes_1, Ls { path: None }, "");
 }

--- a/ipfs-api/src/request/pin.rs
+++ b/ipfs-api/src/request/pin.rs
@@ -28,10 +28,10 @@ impl<'a> ApiRequest for PinAdd<'a> {
 #[derive(Serialize)]
 pub struct PinLs<'a> {
     #[serde(rename = "arg")]
-    pub key: &'a Option<&'a str>,
+    pub key: Option<&'a str>,
 
     #[serde(rename = "type")]
-    pub typ: &'a Option<&'a str>,
+    pub typ: Option<&'a str>,
 }
 
 impl<'a> ApiRequest for PinLs<'a> {

--- a/ipfs-api/src/request/ping.rs
+++ b/ipfs-api/src/request/ping.rs
@@ -10,14 +10,14 @@ use request::ApiRequest;
 
 
 #[derive(Serialize)]
-pub struct Ping<'a, 'b> {
+pub struct Ping<'a> {
     #[serde(rename = "arg")]
     pub peer: &'a str,
 
-    pub count: &'b Option<i32>,
+    pub count: Option<i32>,
 }
 
-impl<'a, 'b> ApiRequest for Ping<'a, 'b> {
+impl<'a> ApiRequest for Ping<'a> {
     #[inline]
     fn path() -> &'static str {
         "/ping"

--- a/ipfs-api/src/request/pubsub.rs
+++ b/ipfs-api/src/request/pubsub.rs
@@ -24,7 +24,7 @@ impl ApiRequest for PubsubLs {
 #[derive(Serialize)]
 pub struct PubsubPeers<'a> {
     #[serde(rename = "arg")]
-    pub topic: &'a Option<&'a str>,
+    pub topic: Option<&'a str>,
 }
 
 impl<'a> ApiRequest for PubsubPeers<'a> {

--- a/ipfs-cli/src/command/files.rs
+++ b/ipfs-cli/src/command/files.rs
@@ -82,7 +82,7 @@ pub fn handle(core: &mut Core, client: &IpfsClient, args: &ArgMatches) {
         ("flush", Some(args)) => {
             let path = args.value_of("PATH");
 
-            core.run(client.files_flush(&path)).expect(EXPECTED_API);
+            core.run(client.files_flush(path)).expect(EXPECTED_API);
 
             println!("");
             println!("  OK");
@@ -90,7 +90,7 @@ pub fn handle(core: &mut Core, client: &IpfsClient, args: &ArgMatches) {
         }
         ("ls", Some(args)) => {
             let path = args.value_of("PATH");
-            let ls = core.run(client.files_ls(&path)).expect(EXPECTED_API);
+            let ls = core.run(client.files_ls(path)).expect(EXPECTED_API);
 
             println!("");
             println!("  entries                :");
@@ -106,7 +106,7 @@ pub fn handle(core: &mut Core, client: &IpfsClient, args: &ArgMatches) {
         ("mkdir", Some(args)) => {
             let path = args.value_of("PATH").unwrap();
 
-            core.run(client.files_mkdir(&path, args.is_present("parents")))
+            core.run(client.files_mkdir(path, args.is_present("parents")))
                 .expect(EXPECTED_API);
 
             println!("");
@@ -125,7 +125,7 @@ pub fn handle(core: &mut Core, client: &IpfsClient, args: &ArgMatches) {
         }
         ("read", Some(args)) => {
             let path = args.value_of("PATH").unwrap();
-            let req = client.files_read(&path).for_each(|chunk| {
+            let req = client.files_read(path).for_each(|chunk| {
                 io::stdout().write_all(&chunk).map_err(From::from)
             });
 
@@ -133,7 +133,7 @@ pub fn handle(core: &mut Core, client: &IpfsClient, args: &ArgMatches) {
         }
         ("rm", Some(args)) => {
             let path = args.value_of("PATH").unwrap();
-            let req = client.files_rm(&path, args.is_present("recursive"));
+            let req = client.files_rm(path, args.is_present("recursive"));
 
             core.run(req).expect(EXPECTED_API);
 
@@ -143,7 +143,7 @@ pub fn handle(core: &mut Core, client: &IpfsClient, args: &ArgMatches) {
         }
         ("stat", Some(args)) => {
             let path = args.value_of("PATH").unwrap();
-            let stat = core.run(client.files_stat(&path)).expect(EXPECTED_API);
+            let stat = core.run(client.files_stat(path)).expect(EXPECTED_API);
 
             println!("");
             println!("  hash                   : {}", stat.hash);

--- a/ipfs-cli/src/command/filestore.rs
+++ b/ipfs-cli/src/command/filestore.rs
@@ -62,7 +62,7 @@ pub fn handle(core: &mut Core, client: &IpfsClient, args: &ArgMatches) {
         }
         ("ls", Some(args)) => {
             let cid = args.value_of("CID");
-            let req = client.filestore_ls(&cid).for_each(print_filestore_object);
+            let req = client.filestore_ls(cid).for_each(print_filestore_object);
 
             println!("");
             core.run(req).expect(EXPECTED_API);
@@ -70,7 +70,7 @@ pub fn handle(core: &mut Core, client: &IpfsClient, args: &ArgMatches) {
         }
         ("verify", Some(args)) => {
             let cid = args.value_of("CID");
-            let req = client.filestore_verify(&cid).for_each(
+            let req = client.filestore_verify(cid).for_each(
                 print_filestore_object,
             );
 


### PR DESCRIPTION
`Option<T>` impl's Copy when `T` is Copy, so `&Option<i32>` and `&Option<&str>` gain you nothing except extra lifetime annotations.