### PR TITLE
Change impl Default to match go-ipfs-api behavior

### DIFF
--- a/ipfs-api/Cargo.toml
+++ b/ipfs-api/Cargo.toml
@@ -28,6 +28,8 @@ tokio                     = "0.1"
 tokio-codec               = "0.1"
 tokio-io                  = "0.1"
 walkdir                   = "2.2"
+dirs                      = "1.0"
+multiaddr                 = "0.3.1"
 
 [dev-dependencies]
 tokio-timer               = "0.2"

--- a/ipfs-api/src/lib.rs
+++ b/ipfs-api/src/lib.rs
@@ -92,6 +92,8 @@ extern crate hyper_multipart_rfc7578 as hyper_multipart;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
+extern crate dirs;
+extern crate multiaddr;
 extern crate serde_json;
 extern crate serde_urlencoded;
 extern crate tokio;


### PR DESCRIPTION
I added code to `impl Default` to use the multiaddr in `~/.ipfs/api` when found, else `localhost:5000`. This matches behavior seen in [go-ipfs-api](https://github.com/ipfs/go-ipfs-api/blob/master/shell.go#L56).