### PR TITLE
Add hyper_tls and IpfsClient::new_from_uri for added HTTPS support

### DIFF
--- a/ipfs-api/Cargo.toml
+++ b/ipfs-api/Cargo.toml
@@ -14,7 +14,7 @@ license                   = "MIT OR Apache-2.0"
 travis-ci                 = { repository = "ferristseng/rust-ipfs-api" }
 
 [features]
-default                   = ["hyper", "hyper-multipart-rfc7578"]
+default                   = ["hyper", "hyper-multipart-rfc7578", "hyper-tls"]
 actix                     = ["actix-web", "actix-multipart-rfc7578"]
 
 [dependencies]
@@ -25,6 +25,7 @@ failure                   = "0.1.2"
 futures                   = "0.1"
 http                      = "0.1"
 hyper                     = { version = "0.12", optional = true }
+hyper-tls                 = { version = "0.3.2", optional = true }
 hyper-multipart-rfc7578   = { version = "0.3", optional = true }
 serde                     = "1.0"
 serde_derive              = "1.0"
@@ -41,5 +42,6 @@ multiaddr                 = "0.3.1"
 actix-multipart-rfc7578   = "0.1"
 actix-web                 = "0.7"
 hyper                     = "0.12"
+hyper-tls                 = "0.3.2"
 tokio-timer               = "0.2"
 tar                       = "0.4"

--- a/ipfs-api/src/lib.rs
+++ b/ipfs-api/src/lib.rs
@@ -182,6 +182,8 @@ extern crate actix_web;
 extern crate hyper;
 #[cfg(feature = "hyper")]
 extern crate hyper_multipart_rfc7578 as hyper_multipart;
+#[cfg(feature = "hyper")]
+extern crate hyper_tls;
 
 extern crate bytes;
 #[macro_use]


### PR DESCRIPTION
Resolves #30. Needed for https://github.com/graphprotocol/graph-node/issues/854.

The `HttpsConnector` provided by hyper-tls supports both HTTP and
HTTPS. Using this instead of the default `HttpConnector` allows to
use the IpfsClient against HTTPS endpoints such as
https://ipfs.infura.io:5001.

To make creating an IpfsClient with an HTTPS URI possible, this
commit adds a new constructor for `IpfsClient`:

```rust
struct IpfsClient {
   ...
   pub fn new_from_uri(uri: &str) -> Result<IpfsClient, InvalidUri> {
      ....
   }
}
```

The existing `IpfsClient::new` constructor is updated to use this.

Tested with the current `ipfs-cli` as well as changing `ipfs-cli`
to use `IpfsClient::new_from_uri("https://ipfs.infura.io:5001")`
instead of `IpfsClient::default()`. Both work.