### PR TITLE
Upgrade actix to v1, bump ipfs-api to v0.5.2

### DIFF
--- a/ipfs-api/Cargo.toml
+++ b/ipfs-api/Cargo.toml
@@ -6,7 +6,7 @@ documentation             = "https://docs.rs/ipfs-api"
 repository                = "https://github.com/ferristseng/rust-ipfs-api"
 keywords                  = ["ipfs"]
 categories                = ["filesystem", "web-programming"]
-version                   = "0.5.1"
+version                   = "0.5.2"
 readme                    = "../README.md"
 license                   = "MIT OR Apache-2.0"
 
@@ -14,14 +14,16 @@ license                   = "MIT OR Apache-2.0"
 travis-ci                 = { repository = "ferristseng/rust-ipfs-api" }
 
 [features]
-default                   = ["hyper", "hyper-multipart-rfc7578", "hyper-tls"]
-actix                     = ["actix-web", "actix-multipart-rfc7578"]
+default                   = ["hyper", "hyper-multipart-rfc7578", "hyper-tls", "failure"]
+actix                     = ["actix-http", "actix-multipart-rfc7578", "awc", "derive_more"]
 
 [dependencies]
-actix-multipart-rfc7578   = { version = "0.1", optional = true }
-actix-web                 = { version = "0.7", optional = true }
+actix-http                = { version = "0.2", optional = true }
+actix-multipart-rfc7578   = { version = "0.2", optional = true }
+awc                       = { version = "0.2", optional = true }
 bytes                     = "0.4"
-failure                   = "0.1.2"
+derive_more               = { version = "0.15.0", optional = true }
+failure                   = { version = "0.1.2", optional = true }
 futures                   = "0.1"
 http                      = "0.1"
 hyper                     = { version = "0.12", optional = true }
@@ -39,8 +41,10 @@ dirs                      = "1.0"
 multiaddr                 = "0.3.1"
 
 [dev-dependencies]
-actix-multipart-rfc7578   = "0.1"
-actix-web                 = "0.7"
+actix-http                = "0.2"
+actix-multipart-rfc7578   = "0.2"
+actix-rt                  = "0.2"
+awc                       = "0.2"
 hyper                     = "0.12"
 hyper-tls                 = "0.3.2"
 tokio-timer               = "0.2"

--- a/ipfs-api/src/lib.rs
+++ b/ipfs-api/src/lib.rs
@@ -56,11 +56,11 @@
 //! #### With Actix
 //!
 //! ```no_run
-//! # extern crate actix_web;
+//! # extern crate actix_rt;
 //! # extern crate futures;
 //! # extern crate ipfs_api;
 //! #
-//! use futures::future::Future;
+//! use futures::future::{Future, lazy};
 //! use ipfs_api::IpfsClient;
 //! use std::io::Cursor;
 //!
@@ -75,12 +75,11 @@
 //!     })
 //!     .map_err(|e| eprintln!("{}", e));
 //!
-//! actix_web::actix::run(|| {
-//!     req.then(|_| {
-//!         actix_web::actix::System::current().stop();
+//! actix_rt::System::new("test").block_on(lazy(|| {
+//!     req.and_then(|_| {
 //!         Ok(())
 //!     })
-//! });
+//! }));
 //! # }
 //! ```
 //!
@@ -119,10 +118,10 @@
 //!
 //! ```no_run
 //! # extern crate futures;
-//! # extern crate actix_web;
+//! # extern crate actix_rt;
 //! # extern crate ipfs_api;
 //! #
-//! use futures::{Future, Stream};
+//! use futures::{Future, lazy, Stream};
 //! use ipfs_api::IpfsClient;
 //! use std::io::{self, Write};
 //!
@@ -140,12 +139,11 @@
 //!     })
 //!     .map_err(|e| eprintln!("{}", e));
 //!
-//! actix_web::actix::run(|| {
-//!     req.then(|_| {
-//!         actix_web::actix::System::current().stop();
+//! actix_rt::System::new("test").block_on(lazy(|| {
+//!     req.and_then(|_| {
 //!         Ok(())
 //!     })
-//! });
+//! }));
 //! # }
 //! ```
 //!
@@ -174,9 +172,11 @@
 //!
 
 #[cfg(feature = "actix")]
+extern crate actix_http;
+#[cfg(feature = "actix")]
 extern crate actix_multipart_rfc7578 as actix_multipart;
 #[cfg(feature = "actix")]
-extern crate actix_web;
+extern crate awc;
 
 #[cfg(feature = "hyper")]
 extern crate hyper;
@@ -186,7 +186,11 @@ extern crate hyper_multipart_rfc7578 as hyper_multipart;
 extern crate hyper_tls;
 
 extern crate bytes;
+#[cfg(feature = "actix")]
 #[macro_use]
+extern crate derive_more;
+#[macro_use]
+#[cfg(feature = "hyper")]
 extern crate failure;
 extern crate futures;
 extern crate http;


### PR DESCRIPTION
A bunch of things have changed with actix in v1 but I'm trying to avoid changing too much. 

* There was a crate re-org which required changing crate deps
* The actix authors replaced `failure` with `derive_more` because actix errors are now !Send + !Sync so I had to do that here as well. I'm up for conditionally choosing derive_more or failure with cfg_if(hyper/actix), just thought it would make error.rs a lot longer.
* From what I've seen, errors related to request-building are now delayed until the request is actually sent, at which time the future is instantly given an Err i.e. invalid URI.