### PR TITLE
Prepare for Rust 2018 migration

### DIFF
--- a/ipfs-api/src/client.rs
+++ b/ipfs-api/src/client.rs
@@ -535,8 +535,8 @@ impl IpfsClient {
 
         for (path, file_size) in paths_to_add {
             let file = std::fs::File::open(&path);
-            if file.is_err() {
-                return Box::new(future::err(file.unwrap_err().into()));
+            if let Err(err) = file {
+                return Box::new(future::err(err.into()));
             }
             let file_name = match prefix {
                 Some(prefix) => path.strip_prefix(prefix).unwrap(),

--- a/ipfs-api/src/client.rs
+++ b/ipfs-api/src/client.rs
@@ -15,19 +15,19 @@ use futures::{
     stream::{self, Stream},
     Future, IntoFuture,
 };
-use header::TRAILER;
+use crate::header::TRAILER;
 use http::uri::{InvalidUri, Uri};
 use http::StatusCode;
 #[cfg(feature = "hyper")]
 use hyper::client::{Client, HttpConnector};
 #[cfg(feature = "hyper")]
-use hyper_multipart::client::multipart;
+use crate::hyper_multipart::client::multipart;
 #[cfg(feature = "hyper")]
 use hyper_tls::HttpsConnector;
 use multiaddr::{AddrComponent, ToMultiaddr};
-use read::{JsonLineDecoder, LineDecoder, StreamReader};
-use request::{self, ApiRequest};
-use response::{self, Error};
+use crate::read::{JsonLineDecoder, LineDecoder, StreamReader};
+use crate::request::{self, ApiRequest};
+use crate::response::{self, Error};
 use serde::{Deserialize, Serialize};
 use serde_json;
 use std::{
@@ -43,14 +43,14 @@ use tokio_codec::{Decoder, FramedRead};
 #[cfg(feature = "actix")]
 type AsyncResponse<T> = Box<Future<Item = T, Error = Error> + 'static>;
 #[cfg(feature = "hyper")]
-type AsyncResponse<T> = Box<Future<Item = T, Error = Error> + Send + 'static>;
+type AsyncResponse<T> = Box<dyn Future<Item = T, Error = Error> + Send + 'static>;
 
 /// A future that returns a stream of responses.
 ///
 #[cfg(feature = "actix")]
 type AsyncStreamResponse<T> = Box<Stream<Item = T, Error = Error> + 'static>;
 #[cfg(feature = "hyper")]
-type AsyncStreamResponse<T> = Box<Stream<Item = T, Error = Error> + Send + 'static>;
+type AsyncStreamResponse<T> = Box<dyn Stream<Item = T, Error = Error> + Send + 'static>;
 
 #[cfg(feature = "actix")]
 type Request = actix_web::client::ClientRequest;
@@ -293,7 +293,7 @@ impl IpfsClient {
                     .request(req)
                     .from_err()
                     .map(move |res| {
-                        let stream: Box<Stream<Item = Res, Error = _> + Send + 'static> =
+                        let stream: Box<dyn Stream<Item = Res, Error = _> + Send + 'static> =
                             match res.status() {
                                 StatusCode::OK => process(res),
                                 // If the server responded with an error status code, the body

--- a/ipfs-api/src/lib.rs
+++ b/ipfs-api/src/lib.rs
@@ -202,8 +202,8 @@ extern crate tokio_codec;
 extern crate tokio_io;
 extern crate walkdir;
 
-pub use client::IpfsClient;
-pub use request::{KeyType, Logger, LoggingLevel, ObjectTemplate};
+pub use crate::client::IpfsClient;
+pub use crate::request::{KeyType, Logger, LoggingLevel, ObjectTemplate};
 
 mod client;
 mod header;

--- a/ipfs-api/src/read.rs
+++ b/ipfs-api/src/read.rs
@@ -8,8 +8,8 @@
 
 use bytes::{Bytes, BytesMut};
 use futures::{Async, Stream};
-use header::X_STREAM_ERROR;
-use response::Error;
+use crate::header::X_STREAM_ERROR;
+use crate::response::Error;
 use serde::Deserialize;
 use serde_json;
 use std::{

--- a/ipfs-api/src/request/add.rs
+++ b/ipfs-api/src/request/add.rs
@@ -7,7 +7,7 @@
 //
 
 use http::Method;
-use request::ApiRequest;
+use crate::request::ApiRequest;
 
 pub struct Add;
 

--- a/ipfs-api/src/request/bitswap.rs
+++ b/ipfs-api/src/request/bitswap.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use request::ApiRequest;
+use crate::request::ApiRequest;
 
 #[derive(Serialize)]
 pub struct BitswapLedger<'a> {

--- a/ipfs-api/src/request/block.rs
+++ b/ipfs-api/src/request/block.rs
@@ -7,7 +7,7 @@
 //
 
 use http::Method;
-use request::ApiRequest;
+use crate::request::ApiRequest;
 
 #[derive(Serialize)]
 pub struct BlockGet<'a> {

--- a/ipfs-api/src/request/bootstrap.rs
+++ b/ipfs-api/src/request/bootstrap.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use request::ApiRequest;
+use crate::request::ApiRequest;
 
 pub struct BootstrapAddDefault;
 

--- a/ipfs-api/src/request/cat.rs
+++ b/ipfs-api/src/request/cat.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use request::ApiRequest;
+use crate::request::ApiRequest;
 
 #[derive(Serialize)]
 pub struct Cat<'a> {

--- a/ipfs-api/src/request/commands.rs
+++ b/ipfs-api/src/request/commands.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use request::ApiRequest;
+use crate::request::ApiRequest;
 
 pub struct Commands;
 

--- a/ipfs-api/src/request/config.rs
+++ b/ipfs-api/src/request/config.rs
@@ -7,7 +7,7 @@
 //
 
 use http::Method;
-use request::ApiRequest;
+use crate::request::ApiRequest;
 
 pub struct ConfigEdit;
 

--- a/ipfs-api/src/request/dag.rs
+++ b/ipfs-api/src/request/dag.rs
@@ -7,7 +7,7 @@
 //
 
 use http::Method;
-use request::ApiRequest;
+use crate::request::ApiRequest;
 
 #[derive(Serialize)]
 pub struct DagGet<'a> {

--- a/ipfs-api/src/request/dag.rs
+++ b/ipfs-api/src/request/dag.rs
@@ -19,6 +19,7 @@ impl<'a> ApiRequest for DagGet<'a> {
     const PATH: &'static str = "/dag/get";
 }
 
+#[allow(dead_code)]
 pub struct DagPut;
 
 impl_skip_serialize!(DagPut);

--- a/ipfs-api/src/request/dht.rs
+++ b/ipfs-api/src/request/dht.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use request::ApiRequest;
+use crate::request::ApiRequest;
 
 #[derive(Serialize)]
 pub struct DhtFindPeer<'a> {

--- a/ipfs-api/src/request/diag.rs
+++ b/ipfs-api/src/request/diag.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use request::ApiRequest;
+use crate::request::ApiRequest;
 
 pub struct DiagCmdsClear;
 

--- a/ipfs-api/src/request/dns.rs
+++ b/ipfs-api/src/request/dns.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use request::ApiRequest;
+use crate::request::ApiRequest;
 
 #[derive(Serialize)]
 pub struct Dns<'a> {

--- a/ipfs-api/src/request/file.rs
+++ b/ipfs-api/src/request/file.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use request::ApiRequest;
+use crate::request::ApiRequest;
 
 #[derive(Serialize)]
 pub struct FileLs<'a> {

--- a/ipfs-api/src/request/files.rs
+++ b/ipfs-api/src/request/files.rs
@@ -7,7 +7,7 @@
 //
 
 use http::Method;
-use request::ApiRequest;
+use crate::request::ApiRequest;
 
 #[derive(Serialize)]
 pub struct FilesCp<'a> {

--- a/ipfs-api/src/request/filestore.rs
+++ b/ipfs-api/src/request/filestore.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use request::ApiRequest;
+use crate::request::ApiRequest;
 
 pub struct FilestoreDups;
 

--- a/ipfs-api/src/request/get.rs
+++ b/ipfs-api/src/request/get.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use request::ApiRequest;
+use crate::request::ApiRequest;
 
 #[derive(Serialize)]
 pub struct Get<'a> {

--- a/ipfs-api/src/request/id.rs
+++ b/ipfs-api/src/request/id.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use request::ApiRequest;
+use crate::request::ApiRequest;
 
 #[derive(Serialize)]
 pub struct Id<'a> {

--- a/ipfs-api/src/request/key.rs
+++ b/ipfs-api/src/request/key.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use request::ApiRequest;
+use crate::request::ApiRequest;
 use serde::ser::{Serialize, Serializer};
 
 #[derive(Copy, Clone)]

--- a/ipfs-api/src/request/log.rs
+++ b/ipfs-api/src/request/log.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use request::ApiRequest;
+use crate::request::ApiRequest;
 use serde::ser::{Serialize, Serializer};
 use std::borrow::Cow;
 

--- a/ipfs-api/src/request/ls.rs
+++ b/ipfs-api/src/request/ls.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use request::ApiRequest;
+use crate::request::ApiRequest;
 
 #[derive(Serialize)]
 pub struct Ls<'a> {

--- a/ipfs-api/src/request/name.rs
+++ b/ipfs-api/src/request/name.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use request::ApiRequest;
+use crate::request::ApiRequest;
 
 #[derive(Serialize)]
 pub struct NamePublish<'a, 'b, 'c, 'd> {

--- a/ipfs-api/src/request/object.rs
+++ b/ipfs-api/src/request/object.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use request::ApiRequest;
+use crate::request::ApiRequest;
 use serde::ser::{Serialize, Serializer};
 
 #[derive(Serialize)]

--- a/ipfs-api/src/request/pin.rs
+++ b/ipfs-api/src/request/pin.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use request::ApiRequest;
+use crate::request::ApiRequest;
 
 #[derive(Serialize)]
 pub struct PinAdd<'a> {

--- a/ipfs-api/src/request/ping.rs
+++ b/ipfs-api/src/request/ping.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use request::ApiRequest;
+use crate::request::ApiRequest;
 
 #[derive(Serialize)]
 pub struct Ping<'a> {

--- a/ipfs-api/src/request/pubsub.rs
+++ b/ipfs-api/src/request/pubsub.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use request::ApiRequest;
+use crate::request::ApiRequest;
 
 pub struct PubsubLs;
 

--- a/ipfs-api/src/request/refs.rs
+++ b/ipfs-api/src/request/refs.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use request::ApiRequest;
+use crate::request::ApiRequest;
 
 pub struct RefsLocal;
 

--- a/ipfs-api/src/request/shutdown.rs
+++ b/ipfs-api/src/request/shutdown.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use request::ApiRequest;
+use crate::request::ApiRequest;
 
 pub struct Shutdown;
 

--- a/ipfs-api/src/request/stats.rs
+++ b/ipfs-api/src/request/stats.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use request::ApiRequest;
+use crate::request::ApiRequest;
 
 pub struct StatsBitswap;
 

--- a/ipfs-api/src/request/swarm.rs
+++ b/ipfs-api/src/request/swarm.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use request::ApiRequest;
+use crate::request::ApiRequest;
 
 pub struct SwarmAddrsLocal;
 

--- a/ipfs-api/src/request/tar.rs
+++ b/ipfs-api/src/request/tar.rs
@@ -7,7 +7,7 @@
 //
 
 use http::Method;
-use request::ApiRequest;
+use crate::request::ApiRequest;
 
 pub struct TarAdd;
 

--- a/ipfs-api/src/request/version.rs
+++ b/ipfs-api/src/request/version.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use request::ApiRequest;
+use crate::request::ApiRequest;
 
 pub struct Version;
 

--- a/ipfs-api/src/response/bitswap.rs
+++ b/ipfs-api/src/response/bitswap.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use response::serde;
+use crate::response::serde;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]

--- a/ipfs-api/src/response/bootstrap.rs
+++ b/ipfs-api/src/response/bootstrap.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use response::serde;
+use crate::response::serde;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]

--- a/ipfs-api/src/response/commands.rs
+++ b/ipfs-api/src/response/commands.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use response::serde;
+use crate::response::serde;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]

--- a/ipfs-api/src/response/dag.rs
+++ b/ipfs-api/src/response/dag.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use response::serde;
+use crate::response::serde;
 use std::collections::HashMap;
 
 #[derive(Debug, Deserialize)]

--- a/ipfs-api/src/response/dht.rs
+++ b/ipfs-api/src/response/dht.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use response::serde;
+use crate::response::serde;
 use serde::de::{Deserialize, Deserializer, Error};
 
 /// See

--- a/ipfs-api/src/response/file.rs
+++ b/ipfs-api/src/response/file.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use response::{serde, IpfsHeader};
+use crate::response::{serde, IpfsHeader};
 use std::collections::HashMap;
 
 #[derive(Debug, Deserialize)]

--- a/ipfs-api/src/response/files.rs
+++ b/ipfs-api/src/response/files.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use response::serde;
+use crate::response::serde;
 
 pub type FilesCpResponse = ();
 

--- a/ipfs-api/src/response/id.rs
+++ b/ipfs-api/src/response/id.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use response::serde;
+use crate::response::serde;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]

--- a/ipfs-api/src/response/key.rs
+++ b/ipfs-api/src/response/key.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use response::serde;
+use crate::response::serde;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]

--- a/ipfs-api/src/response/log.rs
+++ b/ipfs-api/src/response/log.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use response::serde;
+use crate::response::serde;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]

--- a/ipfs-api/src/response/ls.rs
+++ b/ipfs-api/src/response/ls.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use response::serde;
+use crate::response::serde;
 
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]

--- a/ipfs-api/src/response/object.rs
+++ b/ipfs-api/src/response/object.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use response::{serde, IpfsHeader};
+use crate::response::{serde, IpfsHeader};
 use std::collections::HashMap;
 
 #[derive(Debug, Deserialize)]

--- a/ipfs-api/src/response/pin.rs
+++ b/ipfs-api/src/response/pin.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use response::serde;
+use crate::response::serde;
 use std::collections::HashMap;
 
 #[derive(Debug, Deserialize)]

--- a/ipfs-api/src/response/pubsub.rs
+++ b/ipfs-api/src/response/pubsub.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use response::serde;
+use crate::response::serde;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]

--- a/ipfs-api/src/response/repo.rs
+++ b/ipfs-api/src/response/repo.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use response::serde;
+use crate::response::serde;
 use std::collections::HashMap;
 
 #[derive(Deserialize)]

--- a/ipfs-api/src/response/stats.rs
+++ b/ipfs-api/src/response/stats.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use response::{BitswapStatResponse, RepoStatResponse};
+use crate::response::{BitswapStatResponse, RepoStatResponse};
 
 pub type StatsBitswapResponse = BitswapStatResponse;
 

--- a/ipfs-api/src/response/swarm.rs
+++ b/ipfs-api/src/response/swarm.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use response::serde;
+use crate::response::serde;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]

--- a/ipfs-cli/src/command/add.rs
+++ b/ipfs-cli/src/command/add.rs
@@ -7,7 +7,7 @@
 //
 
 use clap::App;
-use command::{CliCommand, EXPECTED_FILE};
+use crate::command::{CliCommand, EXPECTED_FILE};
 use futures::Future;
 use std::path::Path;
 

--- a/ipfs-cli/src/command/bitswap.rs
+++ b/ipfs-cli/src/command/bitswap.rs
@@ -7,7 +7,7 @@
 //
 
 use clap::App;
-use command::CliCommand;
+use crate::command::CliCommand;
 use futures::Future;
 
 pub struct Command;

--- a/ipfs-cli/src/command/block.rs
+++ b/ipfs-cli/src/command/block.rs
@@ -7,7 +7,7 @@
 //
 
 use clap::App;
-use command::{verify_file, CliCommand, EXPECTED_FILE};
+use crate::command::{verify_file, CliCommand, EXPECTED_FILE};
 use futures::{Future, Stream};
 use std::fs::File;
 use std::io::{self, Write};

--- a/ipfs-cli/src/command/bootstrap.rs
+++ b/ipfs-cli/src/command/bootstrap.rs
@@ -7,7 +7,7 @@
 //
 
 use clap::App;
-use command::CliCommand;
+use crate::command::CliCommand;
 use futures::Future;
 
 fn print_peers(peers: &[String]) {

--- a/ipfs-cli/src/command/cat.rs
+++ b/ipfs-cli/src/command/cat.rs
@@ -7,7 +7,7 @@
 //
 
 use clap::App;
-use command::CliCommand;
+use crate::command::CliCommand;
 use futures::{Future, Stream};
 use std::io::{self, Write};
 

--- a/ipfs-cli/src/command/commands.rs
+++ b/ipfs-cli/src/command/commands.rs
@@ -6,7 +6,7 @@
 //
 
 use clap::App;
-use command::CliCommand;
+use crate::command::CliCommand;
 use futures::Future;
 use ipfs_api::response::CommandsResponse;
 

--- a/ipfs-cli/src/command/config.rs
+++ b/ipfs-cli/src/command/config.rs
@@ -7,7 +7,7 @@
 //
 
 use clap::App;
-use command::{verify_file, CliCommand, EXPECTED_FILE};
+use crate::command::{verify_file, CliCommand, EXPECTED_FILE};
 use futures::Future;
 use std::fs::File;
 

--- a/ipfs-cli/src/command/dag.rs
+++ b/ipfs-cli/src/command/dag.rs
@@ -7,7 +7,7 @@
 //
 
 use clap::App;
-use command::CliCommand;
+use crate::command::CliCommand;
 use futures::Future;
 
 pub struct Command;

--- a/ipfs-cli/src/command/dht.rs
+++ b/ipfs-cli/src/command/dht.rs
@@ -7,7 +7,7 @@
 //
 
 use clap::App;
-use command::CliCommand;
+use crate::command::CliCommand;
 use futures::{Future, Stream};
 use ipfs_api::response::DhtMessage;
 

--- a/ipfs-cli/src/command/diag.rs
+++ b/ipfs-cli/src/command/diag.rs
@@ -7,7 +7,7 @@
 //
 
 use clap::{App, Arg, SubCommand};
-use command::CliCommand;
+use crate::command::CliCommand;
 use futures::Future;
 
 pub struct Command;

--- a/ipfs-cli/src/command/dns.rs
+++ b/ipfs-cli/src/command/dns.rs
@@ -7,7 +7,7 @@
 //
 
 use clap::App;
-use command::CliCommand;
+use crate::command::CliCommand;
 use futures::Future;
 
 pub struct Command;

--- a/ipfs-cli/src/command/file.rs
+++ b/ipfs-cli/src/command/file.rs
@@ -7,7 +7,7 @@
 //
 
 use clap::App;
-use command::CliCommand;
+use crate::command::CliCommand;
 use futures::Future;
 
 pub struct Command;

--- a/ipfs-cli/src/command/files.rs
+++ b/ipfs-cli/src/command/files.rs
@@ -7,7 +7,7 @@
 //
 
 use clap::App;
-use command::{verify_file, CliCommand, EXPECTED_FILE};
+use crate::command::{verify_file, CliCommand, EXPECTED_FILE};
 use futures::{Future, Stream};
 use std::fs::File;
 use std::io::{self, Write};

--- a/ipfs-cli/src/command/filestore.rs
+++ b/ipfs-cli/src/command/filestore.rs
@@ -7,7 +7,7 @@
 //
 
 use clap::App;
-use command::CliCommand;
+use crate::command::CliCommand;
 use futures::{Future, Stream};
 use ipfs_api::response::FilestoreObject;
 

--- a/ipfs-cli/src/command/mod.rs
+++ b/ipfs-cli/src/command/mod.rs
@@ -13,7 +13,7 @@ use std::error::Error;
 use std::fs;
 use std::path::Path;
 
-pub type CommandExecutable = Box<Future<Item = (), Error = ()> + 'static + Send>;
+pub type CommandExecutable = Box<dyn Future<Item = (), Error = ()> + 'static + Send>;
 
 pub const EXPECTED_FILE: &str = "expected to read input file";
 
@@ -115,7 +115,7 @@ macro_rules! handle {
         fn handle(
             client: &::ipfs_api::IpfsClient,
             args: &::clap::ArgMatches,
-        ) -> ::command::CommandExecutable {
+        ) -> crate::command::CommandExecutable {
             let $args = args;
             let $client = client;
 
@@ -131,7 +131,7 @@ macro_rules! handle {
         fn handle(
             client: &::ipfs_api::IpfsClient,
             args: &::clap::ArgMatches,
-        ) -> ::command::CommandExecutable {
+        ) -> crate::command::CommandExecutable {
             let $client = client;
             let subcommand = args.subcommand();
 

--- a/ipfs-cli/src/command/shutdown.rs
+++ b/ipfs-cli/src/command/shutdown.rs
@@ -7,7 +7,7 @@
 //
 
 use clap::App;
-use command::CliCommand;
+use crate::command::CliCommand;
 use futures::Future;
 
 pub struct Command;

--- a/ipfs-cli/src/command/version.rs
+++ b/ipfs-cli/src/command/version.rs
@@ -7,7 +7,7 @@
 //
 
 use clap::App;
-use command::CliCommand;
+use crate::command::CliCommand;
 use futures::Future;
 
 pub struct Command;

--- a/ipfs-cli/src/main.rs
+++ b/ipfs-cli/src/main.rs
@@ -12,7 +12,7 @@ extern crate futures;
 extern crate hyper;
 extern crate ipfs_api;
 
-use command::CliCommand;
+use crate::command::CliCommand;
 use ipfs_api::IpfsClient;
 
 mod command;


### PR DESCRIPTION
The preparation changes to migrate `rust-ipfs-api` to Rust 2018.