### PR TITLE
Migrate to Rust 2018 edition

### DIFF
--- a/ipfs-api/Cargo.toml
+++ b/ipfs-api/Cargo.toml
@@ -2,6 +2,7 @@
 name                      = "ipfs-api"
 description               = "Implementation of an IPFS HTTP API client"
 authors                   = ["Ferris Tseng <ferristseng@fastmail.fm>"]
+edition                   = "2018"
 documentation             = "https://docs.rs/ipfs-api"
 repository                = "https://github.com/ferristseng/rust-ipfs-api"
 keywords                  = ["ipfs"]
@@ -29,8 +30,7 @@ http                      = "0.1"
 hyper                     = { version = "0.12", optional = true }
 hyper-tls                 = { version = "0.3.2", optional = true }
 hyper-multipart-rfc7578   = { version = "0.3", optional = true }
-serde                     = "1.0"
-serde_derive              = "1.0"
+serde                     = { version = "1.0", features = ["derive"] }
 serde_json                = "1.0"
 serde_urlencoded          = "0.5"
 tokio                     = "0.1"

--- a/ipfs-api/examples/add_file.rs
+++ b/ipfs-api/examples/add_file.rs
@@ -6,10 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-extern crate futures;
-extern crate ipfs_api;
-extern crate tokio;
-
 use futures::Future;
 use ipfs_api::IpfsClient;
 use std::fs::File;

--- a/ipfs-api/examples/add_tar.rs
+++ b/ipfs-api/examples/add_tar.rs
@@ -6,11 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-extern crate futures;
-extern crate ipfs_api;
-extern crate tar;
-extern crate tokio;
-
 use futures::{Future, Stream};
 use ipfs_api::IpfsClient;
 use std::io::Cursor;

--- a/ipfs-api/examples/bootstrap_default.rs
+++ b/ipfs-api/examples/bootstrap_default.rs
@@ -6,10 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-extern crate futures;
-extern crate ipfs_api;
-extern crate tokio;
-
 use futures::Future;
 use ipfs_api::IpfsClient;
 use tokio::runtime::current_thread::Runtime;

--- a/ipfs-api/examples/dns.rs
+++ b/ipfs-api/examples/dns.rs
@@ -6,10 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-extern crate futures;
-extern crate ipfs_api;
-extern crate tokio;
-
 use futures::Future;
 use ipfs_api::IpfsClient;
 use tokio::runtime::current_thread::Runtime;

--- a/ipfs-api/examples/get_commands.rs
+++ b/ipfs-api/examples/get_commands.rs
@@ -6,10 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-extern crate futures;
-extern crate ipfs_api;
-extern crate tokio;
-
 use futures::Future;
 use ipfs_api::{response, IpfsClient};
 use tokio::runtime::current_thread::Runtime;

--- a/ipfs-api/examples/get_stats.rs
+++ b/ipfs-api/examples/get_stats.rs
@@ -6,10 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-extern crate futures;
-extern crate ipfs_api;
-extern crate tokio;
-
 use futures::Future;
 use ipfs_api::IpfsClient;
 use tokio::runtime::current_thread::Runtime;

--- a/ipfs-api/examples/get_swarm.rs
+++ b/ipfs-api/examples/get_swarm.rs
@@ -6,10 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-extern crate futures;
-extern crate ipfs_api;
-extern crate tokio;
-
 use futures::Future;
 use ipfs_api::IpfsClient;
 use tokio::runtime::current_thread::Runtime;

--- a/ipfs-api/examples/get_version.rs
+++ b/ipfs-api/examples/get_version.rs
@@ -6,10 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-extern crate futures;
-extern crate ipfs_api;
-extern crate tokio;
-
 use futures::Future;
 use ipfs_api::IpfsClient;
 use tokio::runtime::current_thread::Runtime;

--- a/ipfs-api/examples/mfs.rs
+++ b/ipfs-api/examples/mfs.rs
@@ -6,10 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-extern crate futures;
-extern crate ipfs_api;
-extern crate tokio;
-
 use futures::Future;
 use ipfs_api::{response, IpfsClient};
 use std::fs::File;

--- a/ipfs-api/examples/ping_peer.rs
+++ b/ipfs-api/examples/ping_peer.rs
@@ -6,10 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-extern crate futures;
-extern crate ipfs_api;
-extern crate tokio;
-
 use futures::{Future, Stream};
 use ipfs_api::{response::PingResponse, IpfsClient};
 use tokio::runtime::current_thread::Runtime;

--- a/ipfs-api/examples/pubsub.rs
+++ b/ipfs-api/examples/pubsub.rs
@@ -6,11 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-extern crate futures;
-extern crate ipfs_api;
-extern crate tokio;
-extern crate tokio_timer;
-
 use futures::{Future, Stream};
 use ipfs_api::IpfsClient;
 use std::time::{Duration, Instant};

--- a/ipfs-api/examples/replace_config.rs
+++ b/ipfs-api/examples/replace_config.rs
@@ -6,10 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-extern crate futures;
-extern crate ipfs_api;
-extern crate tokio;
-
 use futures::Future;
 use ipfs_api::IpfsClient;
 use std::io::Cursor;

--- a/ipfs-api/examples/resolve_name.rs
+++ b/ipfs-api/examples/resolve_name.rs
@@ -6,10 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-extern crate futures;
-extern crate ipfs_api;
-extern crate tokio;
-
 use futures::Future;
 use ipfs_api::IpfsClient;
 use tokio::runtime::current_thread::Runtime;

--- a/ipfs-api/src/lib.rs
+++ b/ipfs-api/src/lib.rs
@@ -188,13 +188,11 @@ extern crate derive_more;
 #[macro_use]
 #[cfg(feature = "hyper")]
 extern crate failure;
+extern crate dirs;
 extern crate futures;
 extern crate http;
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-extern crate dirs;
 extern crate multiaddr;
+extern crate serde;
 extern crate serde_json;
 extern crate serde_urlencoded;
 extern crate tokio;

--- a/ipfs-api/src/lib.rs
+++ b/ipfs-api/src/lib.rs
@@ -188,17 +188,7 @@ extern crate derive_more;
 #[macro_use]
 #[cfg(feature = "hyper")]
 extern crate failure;
-extern crate dirs;
-extern crate futures;
-extern crate http;
-extern crate multiaddr;
 extern crate serde;
-extern crate serde_json;
-extern crate serde_urlencoded;
-extern crate tokio;
-extern crate tokio_codec;
-extern crate tokio_io;
-extern crate walkdir;
 
 pub use crate::client::IpfsClient;
 pub use crate::request::{KeyType, Logger, LoggingLevel, ObjectTemplate};

--- a/ipfs-api/src/request/bitswap.rs
+++ b/ipfs-api/src/request/bitswap.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::request::ApiRequest;
+use crate::serde::Serialize;
 
 #[derive(Serialize)]
 pub struct BitswapLedger<'a> {

--- a/ipfs-api/src/request/block.rs
+++ b/ipfs-api/src/request/block.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::request::ApiRequest;
+use crate::serde::Serialize;
 use http::Method;
 
 #[derive(Serialize)]

--- a/ipfs-api/src/request/cat.rs
+++ b/ipfs-api/src/request/cat.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::request::ApiRequest;
+use crate::serde::Serialize;
 
 #[derive(Serialize)]
 pub struct Cat<'a> {

--- a/ipfs-api/src/request/dag.rs
+++ b/ipfs-api/src/request/dag.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::request::ApiRequest;
+use crate::serde::Serialize;
 use http::Method;
 
 #[derive(Serialize)]

--- a/ipfs-api/src/request/dht.rs
+++ b/ipfs-api/src/request/dht.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::request::ApiRequest;
+use crate::serde::Serialize;
 
 #[derive(Serialize)]
 pub struct DhtFindPeer<'a> {

--- a/ipfs-api/src/request/diag.rs
+++ b/ipfs-api/src/request/diag.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::request::ApiRequest;
+use crate::serde::Serialize;
 
 pub struct DiagCmdsClear;
 

--- a/ipfs-api/src/request/dns.rs
+++ b/ipfs-api/src/request/dns.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::request::ApiRequest;
+use crate::serde::Serialize;
 
 #[derive(Serialize)]
 pub struct Dns<'a> {

--- a/ipfs-api/src/request/file.rs
+++ b/ipfs-api/src/request/file.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::request::ApiRequest;
+use crate::serde::Serialize;
 
 #[derive(Serialize)]
 pub struct FileLs<'a> {

--- a/ipfs-api/src/request/files.rs
+++ b/ipfs-api/src/request/files.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::request::ApiRequest;
+use crate::serde::Serialize;
 use http::Method;
 
 #[derive(Serialize)]

--- a/ipfs-api/src/request/filestore.rs
+++ b/ipfs-api/src/request/filestore.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::request::ApiRequest;
+use crate::serde::Serialize;
 
 pub struct FilestoreDups;
 

--- a/ipfs-api/src/request/get.rs
+++ b/ipfs-api/src/request/get.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::request::ApiRequest;
+use crate::serde::Serialize;
 
 #[derive(Serialize)]
 pub struct Get<'a> {

--- a/ipfs-api/src/request/id.rs
+++ b/ipfs-api/src/request/id.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::request::ApiRequest;
+use crate::serde::Serialize;
 
 #[derive(Serialize)]
 pub struct Id<'a> {

--- a/ipfs-api/src/request/key.rs
+++ b/ipfs-api/src/request/key.rs
@@ -7,7 +7,7 @@
 //
 
 use crate::request::ApiRequest;
-use serde::ser::{Serialize, Serializer};
+use crate::serde::{Serialize, Serializer};
 
 #[derive(Copy, Clone)]
 pub enum KeyType {

--- a/ipfs-api/src/request/log.rs
+++ b/ipfs-api/src/request/log.rs
@@ -7,7 +7,7 @@
 //
 
 use crate::request::ApiRequest;
-use serde::ser::{Serialize, Serializer};
+use crate::serde::{Serialize, Serializer};
 use std::borrow::Cow;
 
 #[derive(Copy, Clone)]

--- a/ipfs-api/src/request/ls.rs
+++ b/ipfs-api/src/request/ls.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::request::ApiRequest;
+use crate::serde::Serialize;
 
 #[derive(Serialize)]
 pub struct Ls<'a> {

--- a/ipfs-api/src/request/name.rs
+++ b/ipfs-api/src/request/name.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::request::ApiRequest;
+use crate::serde::Serialize;
 
 #[derive(Serialize)]
 pub struct NamePublish<'a, 'b, 'c, 'd> {

--- a/ipfs-api/src/request/object.rs
+++ b/ipfs-api/src/request/object.rs
@@ -7,7 +7,7 @@
 //
 
 use crate::request::ApiRequest;
-use serde::ser::{Serialize, Serializer};
+use crate::serde::{Serialize, Serializer};
 
 #[derive(Serialize)]
 pub struct ObjectData<'a> {

--- a/ipfs-api/src/request/pin.rs
+++ b/ipfs-api/src/request/pin.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::request::ApiRequest;
+use crate::serde::Serialize;
 
 #[derive(Serialize)]
 pub struct PinAdd<'a> {

--- a/ipfs-api/src/request/ping.rs
+++ b/ipfs-api/src/request/ping.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::request::ApiRequest;
+use crate::serde::Serialize;
 
 #[derive(Serialize)]
 pub struct Ping<'a> {

--- a/ipfs-api/src/request/pubsub.rs
+++ b/ipfs-api/src/request/pubsub.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::request::ApiRequest;
+use crate::serde::Serialize;
 
 pub struct PubsubLs;
 

--- a/ipfs-api/src/request/tar.rs
+++ b/ipfs-api/src/request/tar.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::request::ApiRequest;
+use crate::serde::Serialize;
 use http::Method;
 
 pub struct TarAdd;

--- a/ipfs-api/src/response/add.rs
+++ b/ipfs-api/src/response/add.rs
@@ -6,6 +6,8 @@
 // copied, modified, or distributed except according to those terms.
 //
 
+use crate::serde::Deserialize;
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct AddResponse {

--- a/ipfs-api/src/response/bitswap.rs
+++ b/ipfs-api/src/response/bitswap.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::response::serde;
+use crate::serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]

--- a/ipfs-api/src/response/block.rs
+++ b/ipfs-api/src/response/block.rs
@@ -6,6 +6,8 @@
 // copied, modified, or distributed except according to those terms.
 //
 
+use crate::serde::Deserialize;
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct BlockPutResponse {

--- a/ipfs-api/src/response/bootstrap.rs
+++ b/ipfs-api/src/response/bootstrap.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::response::serde;
+use crate::serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]

--- a/ipfs-api/src/response/commands.rs
+++ b/ipfs-api/src/response/commands.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::response::serde;
+use crate::serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]

--- a/ipfs-api/src/response/dag.rs
+++ b/ipfs-api/src/response/dag.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::response::serde;
+use crate::serde::Deserialize;
 use std::collections::HashMap;
 
 #[derive(Debug, Deserialize)]

--- a/ipfs-api/src/response/dht.rs
+++ b/ipfs-api/src/response/dht.rs
@@ -7,7 +7,10 @@
 //
 
 use crate::response::serde;
-use serde::de::{Deserialize, Deserializer, Error};
+use crate::serde::{
+    de::{Deserializer, Error},
+    Deserialize,
+};
 
 /// See
 /// [libp2p](https://github.com/libp2p/go-libp2p-routing/blob/master/notifications/query.go#L16).

--- a/ipfs-api/src/response/dns.rs
+++ b/ipfs-api/src/response/dns.rs
@@ -6,6 +6,8 @@
 // copied, modified, or distributed except according to those terms.
 //
 
+use crate::serde::Deserialize;
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct DnsResponse {

--- a/ipfs-api/src/response/error.rs
+++ b/ipfs-api/src/response/error.rs
@@ -5,6 +5,9 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 //
+
+use crate::serde::Deserialize;
+
 #[cfg(feature = "actix")]
 use awc;
 use http;

--- a/ipfs-api/src/response/file.rs
+++ b/ipfs-api/src/response/file.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::response::{serde, IpfsHeader};
+use crate::serde::Deserialize;
 use std::collections::HashMap;
 
 #[derive(Debug, Deserialize)]

--- a/ipfs-api/src/response/files.rs
+++ b/ipfs-api/src/response/files.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::response::serde;
+use crate::serde::Deserialize;
 
 pub type FilesCpResponse = ();
 

--- a/ipfs-api/src/response/filestore.rs
+++ b/ipfs-api/src/response/filestore.rs
@@ -6,6 +6,8 @@
 // copied, modified, or distributed except according to those terms.
 //
 
+use crate::serde::Deserialize;
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct FilestoreDupsResponse {

--- a/ipfs-api/src/response/id.rs
+++ b/ipfs-api/src/response/id.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::response::serde;
+use crate::serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]

--- a/ipfs-api/src/response/key.rs
+++ b/ipfs-api/src/response/key.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::response::serde;
+use crate::serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]

--- a/ipfs-api/src/response/log.rs
+++ b/ipfs-api/src/response/log.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::response::serde;
+use crate::serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]

--- a/ipfs-api/src/response/ls.rs
+++ b/ipfs-api/src/response/ls.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::response::serde;
+use crate::serde::Deserialize;
 
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]

--- a/ipfs-api/src/response/mod.rs
+++ b/ipfs-api/src/response/mod.rs
@@ -8,6 +8,8 @@
 
 //! This module contains structures returned by the IPFS API.
 
+use crate::serde::Deserialize;
+
 pub use self::add::*;
 pub use self::bitswap::*;
 pub use self::block::*;

--- a/ipfs-api/src/response/mount.rs
+++ b/ipfs-api/src/response/mount.rs
@@ -6,6 +6,8 @@
 // copied, modified, or distributed except according to those terms.
 //
 
+use crate::serde::Deserialize;
+
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct MountResponse {

--- a/ipfs-api/src/response/name.rs
+++ b/ipfs-api/src/response/name.rs
@@ -6,6 +6,8 @@
 // copied, modified, or distributed except according to those terms.
 //
 
+use crate::serde::Deserialize;
+
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct NamePublishResponse {

--- a/ipfs-api/src/response/object.rs
+++ b/ipfs-api/src/response/object.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::response::{serde, IpfsHeader};
+use crate::serde::Deserialize;
 use std::collections::HashMap;
 
 #[derive(Debug, Deserialize)]

--- a/ipfs-api/src/response/pin.rs
+++ b/ipfs-api/src/response/pin.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::response::serde;
+use crate::serde::Deserialize;
 use std::collections::HashMap;
 
 #[derive(Debug, Deserialize)]

--- a/ipfs-api/src/response/ping.rs
+++ b/ipfs-api/src/response/ping.rs
@@ -6,6 +6,8 @@
 // copied, modified, or distributed except according to those terms.
 //
 
+use crate::serde::Deserialize;
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct PingResponse {

--- a/ipfs-api/src/response/pubsub.rs
+++ b/ipfs-api/src/response/pubsub.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::response::serde;
+use crate::serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]

--- a/ipfs-api/src/response/refs.rs
+++ b/ipfs-api/src/response/refs.rs
@@ -6,6 +6,8 @@
 // copied, modified, or distributed except according to those terms.
 //
 
+use crate::serde::Deserialize;
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct RefsLocalResponse {

--- a/ipfs-api/src/response/repo.rs
+++ b/ipfs-api/src/response/repo.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::response::serde;
+use crate::serde::Deserialize;
 use std::collections::HashMap;
 
 #[derive(Deserialize)]

--- a/ipfs-api/src/response/resolve.rs
+++ b/ipfs-api/src/response/resolve.rs
@@ -6,6 +6,8 @@
 // copied, modified, or distributed except according to those terms.
 //
 
+use crate::serde::Deserialize;
+
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct ResolveResponse {

--- a/ipfs-api/src/response/serde.rs
+++ b/ipfs-api/src/response/serde.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use serde::de::{Deserialize, Deserializer, MapAccess, SeqAccess, Visitor};
+use crate::serde::de::{Deserialize, Deserializer, MapAccess, SeqAccess, Visitor};
 use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;

--- a/ipfs-api/src/response/stats.rs
+++ b/ipfs-api/src/response/stats.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::response::{BitswapStatResponse, RepoStatResponse};
+use crate::serde::Deserialize;
 
 pub type StatsBitswapResponse = BitswapStatResponse;
 

--- a/ipfs-api/src/response/swarm.rs
+++ b/ipfs-api/src/response/swarm.rs
@@ -7,6 +7,7 @@
 //
 
 use crate::response::serde;
+use crate::serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]

--- a/ipfs-api/src/response/tar.rs
+++ b/ipfs-api/src/response/tar.rs
@@ -6,6 +6,8 @@
 // copied, modified, or distributed except according to those terms.
 //
 
+use crate::serde::Deserialize;
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct TarAddResponse {

--- a/ipfs-api/src/response/version.rs
+++ b/ipfs-api/src/response/version.rs
@@ -6,6 +6,8 @@
 // copied, modified, or distributed except according to those terms.
 //
 
+use crate::serde::Deserialize;
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct VersionResponse {

--- a/ipfs-cli/Cargo.toml
+++ b/ipfs-cli/Cargo.toml
@@ -2,6 +2,7 @@
 name                      = "ipfs-cli"
 description               = "A CLI to interact with IPFS"
 authors                   = ["Ferris Tseng <ferristseng@fastmail.fm>"]
+edition                   = "2018"
 repository                = "https://github.com/ferristseng/rust-ipfs-api"
 version                   = "0.4.1"
 readme                    = "../README.md"

--- a/ipfs-cli/src/main.rs
+++ b/ipfs-cli/src/main.rs
@@ -8,9 +8,6 @@
 
 #[macro_use]
 extern crate clap;
-extern crate futures;
-extern crate hyper;
-extern crate ipfs_api;
 
 use crate::command::CliCommand;
 use ipfs_api::IpfsClient;


### PR DESCRIPTION
- [x] Working port of **rust-ipfs-api** to **Rust 2018** edition. 