### PR TITLE
Added hyper-rustls feature

### DIFF
--- a/ipfs-api/Cargo.toml
+++ b/ipfs-api/Cargo.toml
@@ -15,7 +15,7 @@ license                   = "MIT OR Apache-2.0"
 travis-ci                 = { repository = "ferristseng/rust-ipfs-api" }
 
 [features]
-default                   = ["hyper", "hyper-multipart-rfc7578", "hyper-tls", "failure"]
+default                   = ["hyper", "hyper-multipart-rfc7578", "hyper-rustls", "failure"]
 actix                     = ["actix-http", "actix-multipart-rfc7578", "awc", "derive_more"]
 
 [dependencies]
@@ -29,6 +29,7 @@ futures                   = "0.1"
 http                      = "0.1"
 hyper                     = { version = "0.12", optional = true }
 hyper-tls                 = { version = "0.3.2", optional = true }
+hyper-rustls              = { version = "0.17.1", optional = true }
 hyper-multipart-rfc7578   = { version = "0.3", optional = true }
 serde                     = { version = "1.0", features = ["derive"] }
 serde_json                = "1.0"
@@ -47,5 +48,6 @@ actix-rt                  = "0.2"
 awc                       = "0.2"
 hyper                     = "0.12"
 hyper-tls                 = "0.3.2"
+hyper-rustls              = "0.17.1"
 tokio-timer               = "0.2"
 tar                       = "0.4"

--- a/ipfs-api/src/client.rs
+++ b/ipfs-api/src/client.rs
@@ -25,8 +25,10 @@ use http::uri::{InvalidUri, Uri};
 use http::StatusCode;
 #[cfg(feature = "hyper")]
 use hyper::client::{self, Builder, HttpConnector};
-#[cfg(feature = "hyper")]
+#[cfg(feature = "hyper-tls")]
 use hyper_tls::HttpsConnector;
+#[cfg(feature = "hyper-rustls")]
+use hyper_rustls::HttpsConnector;
 use multiaddr::{AddrComponent, ToMultiaddr};
 use serde::{Deserialize, Serialize};
 use serde_json;
@@ -131,7 +133,11 @@ impl IpfsClient {
             base: base_path,
             #[cfg(feature = "hyper")]
             client: {
+                #[cfg(feature = "hyper-tls")]
                 let connector = HttpsConnector::new(4).unwrap();
+                #[cfg(feature = "hyper-rustls")]
+                let connector = HttpsConnector::new(4);
+
                 Builder::default().keep_alive(false).build(connector)
             },
             #[cfg(feature = "actix")]

--- a/ipfs-api/src/lib.rs
+++ b/ipfs-api/src/lib.rs
@@ -178,8 +178,10 @@ extern crate awc;
 extern crate hyper;
 #[cfg(feature = "hyper")]
 extern crate hyper_multipart_rfc7578 as hyper_multipart;
-#[cfg(feature = "hyper")]
+#[cfg(feature = "hyper-tls")]
 extern crate hyper_tls;
+#[cfg(feature = "hyper-rustls")]
+extern crate hyper_rustls;
 
 extern crate bytes;
 #[cfg(feature = "actix")]


### PR DESCRIPTION
**Motivation**

`hyper-tls` depends of native OpenSSL library that could be uncomfortable in some cases. In this PR I was added `hyper-rustls` feature that use Rust native implementation for TLS connections.