### PR TITLE
Derive Debug for IpfsClient

### DIFF
--- a/ipfs-api/src/client.rs
+++ b/ipfs-api/src/client.rs
@@ -41,7 +41,7 @@ const FILE_DESCRIPTOR_LIMIT: usize = 127;
 
 /// Asynchronous Ipfs client.
 ///
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct IpfsClient {
     base: Uri,
     client: Client,


### PR DESCRIPTION
Both `awc::Client` and `hyper::client::Client` support `Debug`, allowing to derive `Debug` for `IpfsClient` as well. This makes it possible to print clients like with

```rust
println!("Client: {:?}", IpfsClient::default());
```
which, with `hyper`, will output something like this:
```rust
Client: IpfsClient { base: http://127.0.0.1:5001/api/v0, client: Client }
```