### PR TITLE
Only use POST for IPFS v0.5 compat

### DIFF
--- a/ipfs-api/src/client.rs
+++ b/ipfs-api/src/client.rs
@@ -144,8 +144,9 @@ impl IpfsClient {
         #[cfg(feature = "hyper")]
         {
             url.parse::<Uri>().map_err(From::from).and_then(move |url| {
-                let builder = http::Request::builder();
-                let builder = builder.method(Req::METHOD.clone()).uri(url);
+                let builder = http::Request::builder()
+                    .method("POST")
+                    .uri(url);
 
                 let req = if let Some(form) = form {
                     form.set_body_convert::<hyper::Body, multipart::Body>(builder)
@@ -160,10 +161,10 @@ impl IpfsClient {
         {
             let req = if let Some(form) = form {
                 self.client
-                    .request(Req::METHOD.clone(), url)
+                    .post(url)
                     .content_type(form.content_type())
             } else {
-                self.client.request(Req::METHOD.clone(), url)
+                self.client.post(url)
             };
 
             Ok(req.timeout(std::time::Duration::from_secs(90)))

--- a/ipfs-api/src/request/add.rs
+++ b/ipfs-api/src/request/add.rs
@@ -7,7 +7,6 @@
 //
 
 use crate::request::ApiRequest;
-use http::Method;
 
 pub struct Add;
 
@@ -15,6 +14,4 @@ impl_skip_serialize!(Add);
 
 impl ApiRequest for Add {
     const PATH: &'static str = "/add";
-
-    const METHOD: &'static Method = &Method::POST;
 }

--- a/ipfs-api/src/request/block.rs
+++ b/ipfs-api/src/request/block.rs
@@ -8,7 +8,6 @@
 
 use crate::request::ApiRequest;
 use crate::serde::Serialize;
-use http::Method;
 
 #[derive(Serialize)]
 pub struct BlockGet<'a> {
@@ -26,8 +25,6 @@ impl_skip_serialize!(BlockPut);
 
 impl ApiRequest for BlockPut {
     const PATH: &'static str = "/block/put";
-
-    const METHOD: &'static Method = &Method::POST;
 }
 
 #[derive(Serialize)]

--- a/ipfs-api/src/request/config.rs
+++ b/ipfs-api/src/request/config.rs
@@ -7,7 +7,6 @@
 //
 
 use crate::request::ApiRequest;
-use http::Method;
 
 pub struct ConfigEdit;
 
@@ -23,8 +22,6 @@ impl_skip_serialize!(ConfigReplace);
 
 impl ApiRequest for ConfigReplace {
     const PATH: &'static str = "/config/replace";
-
-    const METHOD: &'static Method = &Method::POST;
 }
 
 pub struct ConfigShow;

--- a/ipfs-api/src/request/dag.rs
+++ b/ipfs-api/src/request/dag.rs
@@ -8,7 +8,6 @@
 
 use crate::request::ApiRequest;
 use crate::serde::Serialize;
-use http::Method;
 
 #[derive(Serialize)]
 pub struct DagGet<'a> {
@@ -27,6 +26,4 @@ impl_skip_serialize!(DagPut);
 
 impl ApiRequest for DagPut {
     const PATH: &'static str = "/dag/put";
-
-    const METHOD: &'static Method = &Method::POST;
 }

--- a/ipfs-api/src/request/files.rs
+++ b/ipfs-api/src/request/files.rs
@@ -8,7 +8,6 @@
 
 use crate::request::ApiRequest;
 use crate::serde::Serialize;
-use http::Method;
 
 #[derive(Serialize)]
 pub struct FilesCp<'a> {
@@ -112,6 +111,4 @@ pub struct FilesWrite<'a> {
 
 impl<'a> ApiRequest for FilesWrite<'a> {
     const PATH: &'static str = "/files/write";
-
-    const METHOD: &'static Method = &Method::POST;
 }

--- a/ipfs-api/src/request/mod.rs
+++ b/ipfs-api/src/request/mod.rs
@@ -106,8 +106,4 @@ pub trait ApiRequest {
     /// All paths should begin with '/'.
     ///
     const PATH: &'static str;
-
-    /// Method used to make the request.
-    ///
-    const METHOD: &'static ::http::Method = &::http::Method::GET;
 }

--- a/ipfs-api/src/request/tar.rs
+++ b/ipfs-api/src/request/tar.rs
@@ -8,7 +8,6 @@
 
 use crate::request::ApiRequest;
 use crate::serde::Serialize;
-use http::Method;
 
 pub struct TarAdd;
 
@@ -16,8 +15,6 @@ impl_skip_serialize!(TarAdd);
 
 impl ApiRequest for TarAdd {
     const PATH: &'static str = "/tar/add";
-
-    const METHOD: &'static Method = &Method::POST;
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
Should fix #49 

Edit: running this as a dependency for a graph-node and tests still not passing... not sure if something else is wrong about IPFS 0.5 compat, so putting this in draft form for now.

Edit 2: graph-node tests pass when using this changeset alongside IPFS v0.4.23. At the very least, this will make the library requests compatible with IPFS v0.5. There is some deeper semantic change that is causing tests to fail downstream, but this is outside the scope of this PR, so therefore, since these changes preserve compatibility with IPFS v0.4.23 but also gets rid of the 405 Method Not Allowed error that pops up when using GET with IPFS v0.5, this is no longer a draft request.