### PR TITLE
Expose requests module and add builder for requests like add_with_opt…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,9 +530,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling_core 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "darling_macro 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fnv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling_core 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "derive_builder"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_builder_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "derive_more"
@@ -918,6 +973,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "idna"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,6 +1023,7 @@ dependencies = [
  "actix-rt 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "awc 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_builder 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.99.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1624,6 +1685,11 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "strsim"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "subtle"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2005,7 +2071,12 @@ dependencies = [
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 "checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
+"checksum darling 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+"checksum darling_core 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+"checksum darling_macro 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 "checksum data-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "11c0346158a19b3627234e15596f5e465c360fcdb97d817bcb255e0510f5a788"
+"checksum derive_builder 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
+"checksum derive_builder_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
 "checksum derive_more 0.99.7 (registry+https://github.com/rust-lang/crates.io-index)" = "2127768764f1556535c01b5326ef94bd60ff08dcfbdc544d53e69ed155610f5d"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
@@ -2048,6 +2119,7 @@ dependencies = [
 "checksum hyper 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96816e1d921eca64d208a85aab4f7798455a8e34229ee5a88c935bdee1b78b14"
 "checksum hyper-multipart-rfc7578 0.4.0-rc (registry+https://github.com/rust-lang/crates.io-index)" = "3a71feb0ce26d0e28969633c06521716b07607f58f55dff84f30214b6c6d256a"
 "checksum hyper-tls 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3adcd308402b9553630734e9c36b77a7e48b3821251ca2493e8cd596763aafaa"
+"checksum ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
@@ -2131,6 +2203,7 @@ dependencies = [
 "checksum smallvec 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
 "checksum socket2 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)" = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
 "checksum static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+"checksum strsim 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum syn 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)" = "1425de3c33b0941002740a420b1a906a350b88d08b82b2c8a01035a3f9447bac"
 "checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"

--- a/ipfs-api/Cargo.toml
+++ b/ipfs-api/Cargo.toml
@@ -23,6 +23,7 @@ actix-http                = { version = "1.0", optional = true }
 actix-multipart-rfc7578   = { version = "0.3.0-rc", optional = true }
 awc                       = { version = "1.0", optional = true }
 bytes                     = "0.5"
+derive_builder            = "0.9"
 derive_more               = { version = "0.99", optional = true }
 failure                   = { version = "0.1.6", optional = true }
 futures                   = "0.3"

--- a/ipfs-api/src/client/internal.rs
+++ b/ipfs-api/src/client/internal.rs
@@ -444,11 +444,43 @@ impl IpfsClient {
     where
         R: 'static + Read + Send + Sync,
     {
+        self.add_with_options(data, request::Add::default()).await
+    }
+
+    /// Add a file to IPFS with options.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # extern crate ipfs_api;
+    /// #
+    /// use ipfs_api::IpfsClient;
+    /// use std::io::Cursor;
+    ///
+    /// # fn main() {
+    /// let client = IpfsClient::default();
+    /// let data = Cursor::new("Hello World!");
+    /// let add =
+    /// ipfs_api::request::AddBuilder::default()
+    /// .chunker("rabin-512-1024-2048").build().unwrap();
+    /// let req = client.add_with_options(data, add);
+    /// # }
+    /// ```
+    ///
+    #[inline]
+    pub async fn add_with_options<R>(
+        &self,
+        data: R,
+        add: request::Add<'_>,
+    ) -> Result<response::AddResponse, Error>
+    where
+        R: 'static + Read + Send + Sync,
+    {
         let mut form = multipart::Form::default();
 
         form.add_reader("path", data);
 
-        self.request(request::Add, Some(form)).await
+        self.request(add, Some(form)).await
     }
 
     /// Add a path to Ipfs. Can be a file or directory.
@@ -515,7 +547,7 @@ impl IpfsClient {
             }
         }
 
-        let req = self.build_base_request(request::Add, Some(form))?;
+        let req = self.build_base_request(request::Add::default(), Some(form))?;
 
         self.request_stream_json(req).try_collect().await
     }

--- a/ipfs-api/src/lib.rs
+++ b/ipfs-api/src/lib.rs
@@ -160,7 +160,7 @@ pub use crate::request::{KeyType, Logger, LoggingLevel, ObjectTemplate};
 mod client;
 mod header;
 mod read;
-mod request;
+pub mod request;
 pub mod response;
 
 #[cfg(feature = "actix")]

--- a/ipfs-api/src/request/add.rs
+++ b/ipfs-api/src/request/add.rs
@@ -7,11 +7,37 @@
 //
 
 use crate::request::ApiRequest;
+use derive_builder::Builder;
+use serde::Serialize;
 
-pub struct Add;
+#[derive(Serialize, Builder, Default)]
+#[serde(rename_all = "kebab-case")]
+#[builder(pattern = "owned", setter(strip_option))]
+pub struct Add<'a> {
+    /// Use trickle-dag format for dag generation.
+    pub trickle: Option<bool>,
+    /// Only chunk and hash - do not write to disk.
+    pub only_hash: Option<bool>,
+    /// Wrap files with a directory object.
+    pub wrap_with_directory: Option<bool>,
+    /// Chunking algorithm, `size-[bytes]`, `rabin-[min]-[avg]-[max]` or `buzhash`.
+    pub chunker: Option<&'a str>,
+    /// Pin this object when adding. Defaults to `true`.
+    pub pin: Option<bool>,
+    /// Use raw blocks for leaf nodes. (experimental).
+    pub raw_leaves: Option<bool>,
+    /// CID version. Defaults to 0 unless an option that depends on CIDv1 is passed.
+    /// (experimental).
+    pub cid_version: Option<u32>,
+    /// Hash function to use. Implies CIDv1 if not sha2-256. (experimental). Default:
+    /// `sha2-256`.
+    pub hash: Option<&'a str>,
+    /// Inline small blocks into CIDs. (experimental).
+    pub inline: Option<bool>,
+    /// Maximum block size to inline. (experimental). Default: `32`.
+    pub inline_limit: Option<u32>,
+}
 
-impl_skip_serialize!(Add);
-
-impl ApiRequest for Add {
+impl<'a> ApiRequest for Add<'a> {
     const PATH: &'static str = "/add";
 }


### PR DESCRIPTION
This is obviously heavily based on #29, I left out some options in the API that wouldn't make sense through this library (`recursive`, `progress`). I went with `derive_builder` mainly because for a fully optional struct, we don't need checks anywhere and I'm not sure the `unwrap` is a massive deal (it could be abstracted away).

One thing that concerns me about this design is that this will result in a lot of `_with_options` methods which do mostly the same thing.

Unfortunately, the only alternative I can think of would be to add a `send(self) -> *Response` method on each `ApiRequest` which would do what the request methods on the client do now, with its own downsides: it's a major change (though it could be hidden from the API) and it would necessary expose the `client.request*` methods (could be `pub(crate)`). I guess it could also be `send(self, FnOnce(self) -> T) -> T` if you want to keep the code in the client and support things like `add_path` nicely too, but that kinda sounds even crazier.

Either would however remove the distinction between, say, `add` and `add_with_options`, replacing them with something like `client.add(data).send()` and `client.add(data).pin(false).send()` respectively.

As it stands I feel like I'm massively overthinking this so I'm just sending this in and if this is acceptable I can extend this to all the methods that accept arguments.