### PR TITLE
ls_with_options

### DIFF
--- a/ipfs-api/src/client/internal.rs
+++ b/ipfs-api/src/client/internal.rs
@@ -1942,13 +1942,47 @@ impl IpfsClient {
     /// use ipfs_api::IpfsClient;
     ///
     /// let client = IpfsClient::default();
-    /// let res = client.ls(None);
     /// let res = client.ls(Some("/ipfs/QmVrLsEDn27sScp3k23sgZNefVTjSAL3wpgW1iWPi4MgoY"));
     /// ```
     ///
     #[inline]
     pub async fn ls(&self, path: Option<&str>) -> Result<response::LsResponse, Error> {
-        self.request(request::Ls { path }, None).await
+        self.request(request::Ls {
+            path: path.expect("Path is not actually optional"),
+            stream: None,
+            resolve_type: None,
+            size: None,
+        }, None).await
+    }
+
+    /// List the contents of an Ipfs multihash.
+    ///
+    /// ```no_run
+    /// use ipfs_api::IpfsClient;
+    ///
+    /// let client = IpfsClient::default();
+    /// #[cfg(feature = "builder")]
+    /// let _ = client.ls_with_options(ipfs_api::request::Ls::builder()
+    ///     .path("/ipfs/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n")
+    ///     .build()
+    /// );
+    /// let _ = client.ls_with_options(ipfs_api::request::Ls {
+    ///     path: "/ipfs/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n",
+    ///     // Example options for fast listing
+    ///     stream: Some(true),
+    ///     resolve_type: Some(false),
+    ///     size: Some(false),
+    /// });
+    /// ```
+    ///
+    #[inline]
+    pub async fn ls_with_options(
+        &self,
+        options: request::Ls<'_>
+    ) -> impl Stream<Item = Result<response::LsResponse, Error>> {
+        impl_stream_api_response! {
+            (self, options, None) => request_stream_json
+        }
     }
 
     // TODO /mount

--- a/ipfs-api/src/client/internal.rs
+++ b/ipfs-api/src/client/internal.rs
@@ -1942,16 +1942,14 @@ impl IpfsClient {
     /// use ipfs_api::IpfsClient;
     ///
     /// let client = IpfsClient::default();
-    /// let res = client.ls(Some("/ipfs/QmVrLsEDn27sScp3k23sgZNefVTjSAL3wpgW1iWPi4MgoY"));
+    /// let res = client.ls("/ipfs/QmVrLsEDn27sScp3k23sgZNefVTjSAL3wpgW1iWPi4MgoY");
     /// ```
     ///
     #[inline]
-    pub async fn ls(&self, path: Option<&str>) -> Result<response::LsResponse, Error> {
+    pub async fn ls(&self, path: &str) -> Result<response::LsResponse, Error> {
         self.request(request::Ls {
-            path: path.expect("Path is not actually optional"),
-            stream: None,
-            resolve_type: None,
-            size: None,
+            path: path,
+            .. Default::default()
         }, None).await
     }
 

--- a/ipfs-api/src/request/ls.rs
+++ b/ipfs-api/src/request/ls.rs
@@ -9,10 +9,21 @@
 use crate::request::ApiRequest;
 use crate::serde::Serialize;
 
-#[derive(Serialize)]
+#[cfg_attr(feature = "builder", derive(TypedBuilder))]
+#[derive(Serialize, Default)]
+#[serde(rename_all = "kebab-case")]
 pub struct Ls<'a> {
     #[serde(rename = "arg")]
-    pub path: Option<&'a str>,
+    pub path: &'a str,
+    /// Resolve linked objects to find out their types. Default: `true`
+    #[cfg_attr(feature = "builder", builder(default, setter(strip_option)))]
+    pub resolve_type: Option<bool>,
+    /// Resolve linked objects to find out their file size. Default: `true`
+    #[cfg_attr(feature = "builder", builder(default, setter(strip_option)))]
+    pub size: Option<bool>,
+    /// Enable experimental streaming of directory entries as they are traversed.
+    #[cfg_attr(feature = "builder", builder(default, setter(strip_option)))]
+    pub stream: Option<bool>,
 }
 
 impl<'a> ApiRequest for Ls<'a> {
@@ -23,6 +34,6 @@ impl<'a> ApiRequest for Ls<'a> {
 mod tests {
     use super::Ls;
 
-    serialize_url_test!(test_serializes_0, Ls { path: Some("test") }, "arg=test");
-    serialize_url_test!(test_serializes_1, Ls { path: None }, "");
+    serialize_url_test!(test_serializes_0, Ls { path: "test", .. Default::default() }, "arg=test");
+    serialize_url_test!(test_serializes_1, Ls { path: "asdf", resolve_type: Some(true), size: Some(true), stream: Some(false) }, "arg=asdf&resolve-type=true&size=true&stream=false");
 }


### PR DESCRIPTION
This adds options to [`ipfs ls`](https://docs.ipfs.io/reference/http/api/#api-v0-ls) in the style of #54.

In theory, this should be a no-brainer. In practice, there's a small detail: the path parameter to `ls` is not actually optional, I don't know why it's an `Option` on `IpfsClient::ls`, and I'd prefer not to replicate that mistake. I've made it so the API doesn't break. If you want me to break `IpfsClient::ls` for consistency and correctnesses sake, please tell me.

(Btw, these are rather necessary to list large folders: `ipfs ls --stream --resolve-type=false --size=false /ipfs/bafybeicupvauz2urhyg7brbqy37z6ytorxmsog7uns6scntmd3cpvxfnyu/distfiles` should complete in about 20 minutes. Remove   `--stream` and you just get no output for a very long time (but it does compelete). Remove the other two, too, and my node crashes. Though admittedly, folders with 10000s of items are rare.)