### PR TITLE
Add an interface to specify --timeout, --offline, --cid-ver, ...

### DIFF
--- a/ipfs-api/src/client/internal.rs
+++ b/ipfs-api/src/client/internal.rs
@@ -37,6 +37,7 @@ use std::{
     path::{Path, PathBuf},
 };
 use tokio_util::codec::{Decoder, FramedRead};
+use crate::request::global_options::GlobalOptions;
 
 fn default<T: Default>() -> T {
     Default::default()
@@ -53,6 +54,23 @@ const ACTIX_REQUEST_TIMEOUT: Duration = Duration::from_secs(90);
 pub struct IpfsClient {
     base: Uri,
     client: Client,
+
+    /// Can be used to configure some of the global IPFS API options
+    ///
+    /// Example:
+    ///
+    /// ```no_run
+    /// use ipfs_api::IpfsClient;
+    ///
+    ///# async fn foo() -> bool {
+    /// let mut client = IpfsClient::default();
+    /// // check whether you unpinned the initial files on your node:
+    /// client.global_options.offline = Some(true);
+    /// client.object_stat("QmPXME1oRtoT627YKaDPDQ3PwA8tdP9rWuAAweLzqSwAWT").await.is_ok()
+    ///# }
+    /// ```
+    ///
+    pub global_options: GlobalOptions,
 }
 
 impl TryFromUri for IpfsClient {
@@ -72,7 +90,7 @@ impl TryFromUri for IpfsClient {
             }
         };
 
-        IpfsClient { base: uri, client }
+        IpfsClient { base: uri, client, global_options: GlobalOptions::default() }
     }
 }
 
@@ -97,11 +115,20 @@ impl IpfsClient {
     where
         Req: ApiRequest + Serialize,
     {
+        #[derive(Serialize)]
+        struct OptCombiner<'a, Req> {
+            #[serde(flatten)]
+            global: &'a GlobalOptions,
+            #[serde(flatten)]
+            request: &'a Req,
+        }
+        let query = OptCombiner { global: &self.global_options, request: &req };
+
         let url = format!(
             "{}{}?{}",
             self.base,
             Req::PATH,
-            ::serde_urlencoded::to_string(req)?
+            ::serde_urlencoded::to_string(query)?
         );
 
         #[cfg(feature = "hyper")]

--- a/ipfs-api/src/request/mod.rs
+++ b/ipfs-api/src/request/mod.rs
@@ -97,6 +97,7 @@ mod stats;
 mod swarm;
 mod tar;
 mod version;
+pub mod global_options;
 
 /// A request that can be made against the Ipfs API.
 ///


### PR DESCRIPTION
This is a draft implementing #62 (cc @ec1oud).
Implementing, as a feature, a way to specify `--offline` is fairly simple.
Providing a sane interface not so much.

* Exposing a pub member of the client struct feels wrong, but I don't see what difference having setters and getters would make.
* Specifying timeouts that differ per request is annoying (and a bit inefficient), requires cloning each time..
* To make matters more complicated, there are also group-global options (check e.g. `ipfs files --help`, showing `--flush`), which one might eventually want to support
* The current call-style api does not lend it self to global parameters, imho.

I've contemplated breaking it up into groups, but that'd be a rather large change, leading to something like `client.with_opts(global_ops).files(files_opts).write_with_opts("foo", write_opts)`, but that'd be a rather large breaking change.

Anyone with any neat suggestions for an interface?