### PR TITLE
Support --offline and --timeout

### DIFF
--- a/ipfs-api-backend-actix/src/lib.rs
+++ b/ipfs-api-backend-actix/src/lib.rs
@@ -14,5 +14,5 @@ mod error;
 pub use crate::{backend::ActixBackend as IpfsClient, error::Error};
 pub use ipfs_api_prelude::{
     request::{self, KeyType, Logger, LoggingLevel, ObjectTemplate},
-    response, IpfsApi, TryFromUri,
+    response, ApiError, BackendWithGlobalOptions, GlobalOptions, IpfsApi, TryFromUri,
 };

--- a/ipfs-api-backend-hyper/src/lib.rs
+++ b/ipfs-api-backend-hyper/src/lib.rs
@@ -14,5 +14,5 @@ mod error;
 pub use crate::{backend::HyperBackend as IpfsClient, error::Error};
 pub use ipfs_api_prelude::{
     request::{self, KeyType, Logger, LoggingLevel, ObjectTemplate},
-    response, IpfsApi, TryFromUri,
+    response, ApiError, BackendWithGlobalOptions, GlobalOptions, IpfsApi, TryFromUri,
 };

--- a/ipfs-api-examples/Cargo.toml
+++ b/ipfs-api-examples/Cargo.toml
@@ -25,6 +25,7 @@ actix-rt                  = { version = "2.2", optional = true }
 futures                   = "0.3"
 ipfs-api-backend-actix    = { version = "0.2", path = "../ipfs-api-backend-actix", optional = true }
 ipfs-api-backend-hyper    = { version = "0.1", path = "../ipfs-api-backend-hyper", optional = true }
+ipfs-api-prelude          = { version = "0.1", path = "../ipfs-api-prelude", features = ["with-builder"] }
 tar                       = "0.4"
 tokio                     = { version = "1", features = ["time"] }
 tokio-stream              = { version = "0.1", features = ["time"] }

--- a/ipfs-api-examples/examples/check_file_local.rs
+++ b/ipfs-api-examples/examples/check_file_local.rs
@@ -1,0 +1,71 @@
+// Copyright 2021 rust-ipfs-api Developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+//
+
+use futures::StreamExt;
+use ipfs_api_examples::ipfs_api::{
+    request::Ls, response::LsResponse, ApiError, BackendWithGlobalOptions, Error as IpfsError,
+    GlobalOptions, IpfsApi, IpfsClient,
+};
+use std::process::exit;
+
+// Creates an Ipfs client, and recursively checks whether argv[1] is cached on the local node.
+//
+#[ipfs_api_examples::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+
+    eprintln!("note: this must be run in the root of the project repository");
+    eprintln!("connecting to localhost:5001...");
+
+    let client = BackendWithGlobalOptions::new(
+        IpfsClient::default(),
+        GlobalOptions::builder()
+            .offline(true) // This is the entire trick!
+            .build(),
+    );
+    // See also: https://discuss.ipfs.io/t/how-to-check-if-an-ipfs-object-is-on-your-local-node/1250/2
+    // Note that if you have the file in mfs (ipfs files ...), ipfs files stat --with-local is likely faster
+
+    let start_cid = std::env::args()
+        .nth(1)
+        .unwrap_or("QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn".into());
+    let mut cids = vec![start_cid];
+
+    while let Some(cid) = cids.pop() {
+        println!("Checking {}", cid);
+        let mut ls = client.ls_with_options(
+            Ls::builder()
+                .path(&cid)
+                .resolve_type(false)
+                .size(false)
+                .build(),
+        );
+        while let Some(ls_chunk) = ls.next().await {
+            match ls_chunk {
+                Ok(LsResponse { objects, .. }) => {
+                    for object in objects {
+                        for file in object.links {
+                            cids.push(file.hash)
+                        }
+                    }
+                }
+                Err(IpfsError::Api(ApiError { message, .. })) => {
+                    // A better implementation would check for the semantic equivalent of "mergkledag: not found"
+                    // I don't match on error messages by principle
+                    println!("{} may be not local: {}", cid, message);
+                    exit(1);
+                }
+                Err(e) => {
+                    println!("Error while walking: {:?}", e);
+                    exit(-1);
+                }
+            }
+        }
+    }
+    println!("All local");
+}

--- a/ipfs-api-prelude/src/global_opts.rs
+++ b/ipfs-api-prelude/src/global_opts.rs
@@ -1,0 +1,129 @@
+use crate::{request::ApiRequest, Backend};
+use serde::{Serialize, Serializer};
+use std::time::Duration;
+
+/// Options valid on any IPFS Api request
+///
+/// Can be set on a client using [BackendWithGlobalOptions]
+///
+#[cfg_attr(feature = "with-builder", derive(TypedBuilder))]
+#[derive(Serialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct GlobalOptions {
+    #[cfg_attr(feature = "with-builder", builder(default, setter(strip_option)))]
+    pub offline: Option<bool>,
+    #[cfg_attr(feature = "with-builder", builder(default, setter(strip_option)))]
+    #[serde(serialize_with = "duration_as_secs_ns")]
+    pub timeout: Option<Duration>,
+}
+
+fn duration_as_secs_ns<S>(duration: &Option<Duration>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match duration {
+        Some(duration) => serializer.serialize_str(&format!(
+            "{}s{}ns",
+            duration.as_secs(),
+            duration.subsec_nanos(),
+        )),
+        None => serializer.serialize_none(),
+    }
+}
+
+/// A wrapper for [Backend] / [IpfsApi](crate::api::IpfsApi) that adds global options
+pub struct BackendWithGlobalOptions<Back: Backend> {
+    pub(crate) backend: Back,
+    pub(crate) options: GlobalOptions,
+}
+
+#[derive(Serialize)]
+struct OptCombiner<'a, Req> {
+    #[serde(flatten)]
+    global: &'a GlobalOptions,
+    #[serde(flatten)]
+    request: &'a Req,
+}
+
+impl<Back: Backend> BackendWithGlobalOptions<Back> {
+    /// Return the wrapped [Backend]
+    pub fn into_inner(self) -> Back {
+        self.backend
+    }
+
+    /// Construct
+    ///
+    /// While possible, it is not recommended to wrap a [Backend] twice.
+    pub fn new(backend: Back, options: GlobalOptions) -> Self {
+        Self { backend, options }
+    }
+
+    fn combine<'a, Req: ApiRequest>(&'a self, req: &'a Req) -> OptCombiner<'a, Req> {
+        OptCombiner {
+            global: &self.options,
+            request: &req,
+        }
+    }
+}
+
+impl<'a, Req: ApiRequest> ApiRequest for OptCombiner<'a, Req> {
+    const PATH: &'static str = <Req as ApiRequest>::PATH;
+
+    const METHOD: http::Method = http::Method::POST;
+}
+
+#[async_trait::async_trait(?Send)]
+impl<Back: Backend> Backend for BackendWithGlobalOptions<Back> {
+    type HttpRequest = Back::HttpRequest;
+
+    type HttpResponse = Back::HttpResponse;
+
+    type Error = Back::Error;
+
+    fn build_base_request<Req>(
+        &self,
+        req: &Req,
+        form: Option<common_multipart_rfc7578::client::multipart::Form<'static>>,
+    ) -> Result<Self::HttpRequest, Self::Error>
+    where
+        Req: ApiRequest,
+    {
+        self.backend.build_base_request(&self.combine(req), form)
+    }
+
+    fn get_header(
+        res: &Self::HttpResponse,
+        key: http::header::HeaderName,
+    ) -> Option<&http::HeaderValue> {
+        Back::get_header(res, key)
+    }
+
+    async fn request_raw<Req>(
+        &self,
+        req: Req,
+        form: Option<common_multipart_rfc7578::client::multipart::Form<'static>>,
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error>
+    where
+        Req: ApiRequest + Serialize,
+    {
+        self.backend.request_raw(self.combine(&req), form).await
+    }
+
+    fn response_to_byte_stream(
+        res: Self::HttpResponse,
+    ) -> Box<dyn futures::Stream<Item = Result<bytes::Bytes, Self::Error>> + Unpin> {
+        Back::response_to_byte_stream(res)
+    }
+
+    fn request_stream<Res, F, OutStream>(
+        &self,
+        req: Self::HttpRequest,
+        process: F,
+    ) -> Box<dyn futures::Stream<Item = Result<Res, Self::Error>> + Unpin>
+    where
+        OutStream: futures::Stream<Item = Result<Res, Self::Error>> + Unpin,
+        F: 'static + Fn(Self::HttpResponse) -> OutStream,
+    {
+        self.backend.request_stream(req, process)
+    }
+}

--- a/ipfs-api-prelude/src/lib.rs
+++ b/ipfs-api-prelude/src/lib.rs
@@ -16,12 +16,18 @@ mod api;
 mod backend;
 mod error;
 mod from_uri;
+mod global_opts;
 mod header;
 mod read;
 pub mod request;
 pub mod response;
 
 pub use {
-    api::IpfsApi, backend::Backend, error::Error, from_uri::TryFromUri, request::ApiRequest,
+    api::IpfsApi,
+    backend::Backend,
+    error::Error,
+    from_uri::TryFromUri,
+    global_opts::{BackendWithGlobalOptions, GlobalOptions},
+    request::ApiRequest,
     response::ApiError,
 };


### PR DESCRIPTION
Reopen of #65 because I messed up and closed that one.

I'm still unsure about the API. I don't really want to expose `BackendWithGlobalOptions` publicly, but
* I originally had a `with_global_options` on `Backend` (and `IpfsApi`), but then you could call that twice and you'd get the global options set twice. Kinda meh.
* I could add the `with_global_options` on the `IpfsClient`s, but since they're in a different crate, I still have to expose `BackendWithGlobalOptions` as `pub`. The recommended interface gets nicer, the actual interface doesn't change.

I also don't have a plan for what to do with  things like `ipfs files`*`--flush`*.