### PR TITLE
HTTP Basic authorization option

### DIFF
--- a/ipfs-api-backend-hyper/Cargo.toml
+++ b/ipfs-api-backend-hyper/Cargo.toml
@@ -23,6 +23,7 @@ with-send-sync            = ["ipfs-api-prelude/with-send-sync"]
 
 [dependencies]
 async-trait               = "0.1"
+base64                    = "0.13"
 bytes                     = "1"
 futures                   = "0.3"
 http                      = "0.2"


### PR DESCRIPTION
This PR is a crude solution to add HTTP Basic auth headers to IPFS requests.
This is not a full-fledged merge request, more like a quick hacky solution to show the intent, and to start a discussion on this topic. By the way it would be nice to enable the Discussions section in the repository, it would help with things like this in the future.

My use-case: The paid version of Infura IPFS uses Basic auth on top of the standard IPFS communication to identify clients

The solution is tested and works fine, which is enough for my use-case, but I wanted to see if this feature would be a welcome addition, and discuss what is needed to be done to flesh out this PR into a real solution. So what whould be the optimal way to support this? Should we add it to both Hyper and Actix backends? Where should the config data live? What would be the best way to configure the Backend? Should we add a Builder like solution or is a mutable function fine?

Also I had to add base64 as a new dependency, because Hyper doesn't have built in Basic auth support. Hyper is intentionally a low-level crate, but it's higher level counterpart Reqwest has support for it. I thought a single feature doesn't really worth the hassle of changing to a Reqwest backend (or adding it as a new backend), so instead I just added the base64 crate and implemented the Authorization header construction manually.

Let me know your thoughts!