### PR TITLE
Supplement the examples and documents of ipfs-api-backend-actix crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ use std::io::Cursor;
 
 #[actix_rt::main]
 async fn main() {
-    let client = IpfsClient::from_str("http://101.43.52.162:5001").unwrap();
+    let client = IpfsClient::from_str("http://127.0.0.1:5001").unwrap();
     let data = Cursor::new("test ipfs server!");
 
     match client.add(data).await {

--- a/README.md
+++ b/README.md
@@ -142,7 +142,25 @@ async fn main() {
 ```
 
 ##### With Actix
+When you use `ipfs-api-backend-actix` crates
+```rust
+use ipfs_api_backend_actix::{IpfsApi, IpfsClient, TryFromUri};
+use std::io::Cursor;
 
+#[actix_rt::main]
+async fn main() {
+    let client = IpfsClient::from_str("http://101.43.52.162:5001").unwrap();
+    let data = Cursor::new("test ipfs server!");
+
+    match client.add(data).await {
+        Ok(res) => println!("{}", res.hash),
+        Err(e) => eprintln!("error adding file: {}", e)
+    }
+}
+```
+
+
+When you use `ipfs_api` crates
 ```rust
 use futures::TryStreamExt;
 use ipfs_api::{IpfsApi, IpfsClient};

--- a/ipfs-api-examples/examples/actix_custom_conn.rs
+++ b/ipfs-api-examples/examples/actix_custom_conn.rs
@@ -1,0 +1,21 @@
+// Copyright 2021 rust-ipfs-api Developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+//
+
+use ipfs_api_backend_actix::{IpfsApi, IpfsClient, TryFromUri};
+use std::io::Cursor;
+
+#[actix_rt::main]
+async fn main() {
+    let client = IpfsClient::from_str("http://127.0.0.1:5001").unwrap();
+    let data = Cursor::new("Test IPFS Server!");
+
+    match client.add(data).await {
+        Ok(res) => println!("{}", res.hash),
+        Err(e) => eprintln!("error adding file: {}", e)
+    }
+}


### PR DESCRIPTION
In order to help developers use the new crates, some relevant documents and examples should be provided