### PR TITLE
Basic Authentication

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,61 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  build-actix:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build (Actix)
+      run: cd ipfs-api; cargo build --verbose --features with-actix --no-default-features
+    - name: Build examples (Actix)
+      run: cargo build --verbose --examples --no-default-features --features with-actix
+    - name: Build tests (Actix)
+      run: cd ipfs-api; cargo test --verbose --features with-actix --no-default-features --no-run
+    - name: Run tests (Actix)
+      run: cd ipfs-api; cargo test --verbose --features with-actix --no-default-features
+
+  build-default:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+    - name: Build examples
+      run: cargo build --verbose --examples
+    - name: Build tests
+      run: cargo test --verbose --no-run
+    - name: Run tests
+      run: cargo test --verbose
+
+  build-hyper:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build (Hyper with tls)
+      run: cd ipfs-api; cargo build --verbose --features with-hyper-tls --no-default-features
+    - name: Build examples (Hyper with tls)
+      run: cargo build --verbose --examples --no-default-features --features with-hyper-tls
+    - name: Build tests (Hyper with tls)
+      run: cargo test --verbose --features with-hyper-tls --no-default-features --no-run
+    - name: Run tests (Hyper with tls)
+      run: cargo test --verbose --features with-hyper-tls --no-default-features
+
+    - name: Build (Hyper with rustls)
+      run: cd ipfs-api; cargo build --verbose --features with-hyper-rustls --no-default-features
+    - name: Build examples (Hyper with rustls)
+      run: cargo build --verbose --examples --no-default-features --features with-hyper-rustls
+
+    - name: Build (Hyper with Send trait)
+      run: cd ipfs-api-backend-hyper; cargo build --verbose --features with-send-sync
+
+  other:
 
     runs-on: ubuntu-latest
 
@@ -21,25 +75,3 @@ jobs:
     - name: Clippy
       shell: bash
       run: cargo clippy --all-targets -- -D warnings
-    - name: Build (Default)
-      run: cargo build --verbose
-    - name: Build examples (Default)
-      run: cargo build --verbose --examples
-    - name: Build examples (Actix)
-      run: cargo build --verbose --examples --no-default-features --features with-actix
-    - name: Build examples (Hyper with tls)
-      run: cargo build --verbose --examples --no-default-features --features with-hyper-tls
-    - name: Build examples (Hyper with rustls)
-      run: cargo build --verbose --examples --no-default-features --features with-hyper-rustls
-    - name: Run tests (Default)
-      run: cargo test --verbose
-    - name: Build (Actix)
-      run: cd ipfs-api; cargo build --verbose --features with-actix --no-default-features
-    - name: Run tests (Actix)
-      run: cd ipfs-api; cargo test --verbose --features with-actix --no-default-features
-    - name: Build (Hyper with tls)
-      run: cd ipfs-api; cargo build --verbose --features with-hyper-tls --no-default-features
-    - name: Build (Hyper with rustls)
-      run: cd ipfs-api; cargo build --verbose --features with-hyper-rustls --no-default-features
-    - name: Build (Hyper with Send trait)
-      run: cd ipfs-api-backend-hyper; cargo build --verbose --features with-send-sync

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ members = [
   "ipfs-api-backend-hyper",
   "ipfs-api-examples",
   "ipfs-api-prelude",
+  "ipfs-api-versions",
 ]

--- a/ipfs-api-backend-hyper/Cargo.toml
+++ b/ipfs-api-backend-hyper/Cargo.toml
@@ -23,6 +23,7 @@ with-send-sync            = ["ipfs-api-prelude/with-send-sync"]
 
 [dependencies]
 async-trait               = "0.1"
+base64                    = "0.13"
 bytes                     = "1"
 futures                   = "0.3"
 http                      = "0.2"

--- a/ipfs-api-examples/examples/basic_auth.rs
+++ b/ipfs-api-examples/examples/basic_auth.rs
@@ -1,0 +1,33 @@
+// Copyright 2022 rust-ipfs-api Developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use std::env;
+
+use ipfs_api_examples::ipfs_api::{IpfsApi, IpfsClient, TryFromUri};
+
+fn expect_env(key: &str) -> String {
+    env::var(key).expect(key)
+}
+
+/// Creates an IPFS client, and sets credentials to use.
+#[ipfs_api_examples::main]
+async fn main() {
+    let ipfs_api_url = expect_env("IPFS_API_URL");
+    let ipfs_api_username = expect_env("IPFS_API_USERNAME");
+    let ipfs_api_password = expect_env("IPFS_API_PASSWORD");
+
+    println!("Connecting to {} as {}...", ipfs_api_url, ipfs_api_username);
+
+    let client = IpfsClient::from_str(&ipfs_api_url)
+        .unwrap()
+        .with_credentials(ipfs_api_username, ipfs_api_password);
+
+    match client.version().await {
+        Ok(version) => println!("version: {}", version.version),
+        Err(e) => eprintln!("error getting version: {}", e),
+    }
+}

--- a/ipfs-api-examples/examples/get_version.rs
+++ b/ipfs-api-examples/examples/get_version.rs
@@ -19,7 +19,7 @@ async fn main() {
     let client = IpfsClient::default();
 
     match client.version().await {
-        Ok(version) => eprintln!("version: {:?}", version.version),
+        Ok(version) => println!("version: {}", version.version),
         Err(e) => eprintln!("error getting version: {}", e),
     }
 }

--- a/ipfs-api-prelude/src/backend.rs
+++ b/ipfs-api-prelude/src/backend.rs
@@ -236,4 +236,10 @@ pub trait Backend {
             )
         })
     }
+
+    /// Set basic authentication credentials to use on every request from this client.
+    fn with_credentials<U, P>(self, username: U, password: P) -> Self
+    where
+        U: Into<String>,
+        P: Into<String>;
 }

--- a/ipfs-api-prelude/src/global_opts.rs
+++ b/ipfs-api-prelude/src/global_opts.rs
@@ -74,6 +74,17 @@ impl<Back: Backend> BackendWithGlobalOptions<Back> {
         Self { backend, options }
     }
 
+    fn with_credentials<U, P>(self, username: U, password: P) -> Self
+    where
+        U: Into<String>,
+        P: Into<String>,
+    {
+        Self {
+            backend: self.backend.with_credentials(username, password),
+            options: self.options,
+        }
+    }
+
     fn combine<Req>(&self, req: Req) -> OptCombiner<Req>
     where
         Req: ApiRequest,
@@ -102,6 +113,14 @@ impl<Back: Backend + Send + Sync> Backend for BackendWithGlobalOptions<Back> {
     type HttpResponse = Back::HttpResponse;
 
     type Error = Back::Error;
+
+    fn with_credentials<U, P>(self, username: U, password: P) -> Self
+    where
+        U: Into<String>,
+        P: Into<String>,
+    {
+        (self as BackendWithGlobalOptions<Back>).with_credentials(username, password)
+    }
 
     fn build_base_request<Req>(
         &self,
@@ -156,6 +175,14 @@ impl<Back: Backend> Backend for BackendWithGlobalOptions<Back> {
     type HttpResponse = Back::HttpResponse;
 
     type Error = Back::Error;
+
+    fn with_credentials<U, P>(self, username: U, password: P) -> Self
+    where
+        U: Into<String>,
+        P: Into<String>,
+    {
+        (self as BackendWithGlobalOptions<Back>).with_credentials(username, password)
+    }
 
     fn build_base_request<Req>(
         &self,

--- a/ipfs-api-versions/Cargo.toml
+++ b/ipfs-api-versions/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+description               = "Test support crate defining which IPFS versions are tested against"
+edition                   = "2021"
+license                   = "MIT OR Apache-2.0"
+name                      = "ipfs-api-versions"
+documentation             = "https://docs.rs/ipfs-api"
+readme                    = "../README.md"
+repository                = "https://github.com/ferristseng/rust-ipfs-api"
+version                   = "0.1.0"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+
+[dev-dependencies]
+test-case = "2.2"

--- a/ipfs-api-versions/src/lib.rs
+++ b/ipfs-api-versions/src/lib.rs
@@ -1,0 +1,125 @@
+// Copyright 2022 rust-ipfs-api Developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Define which IPFS (Kubo) Docker images the Rust library will be tested against.
+//!
+//! # Examples
+//!
+//! ```rust
+//! use ipfs_api_versions::test_current_image;
+//!
+//! #[test_current_image]
+//! fn test_foo(image_name: &str, image_tag: &str) {
+//!     // ...test implementation to run against only the latest image
+//! }
+//! ```
+//!
+//! ```rust
+//! use ipfs_api_versions::test_supported_images;
+//!
+//! #[test_supported_images]
+//! fn test_bar(image_name: &str, image_tag: &str) {
+//!     // ...test implementation to run against all supported images
+//! }
+//! ```
+
+use proc_macro::TokenStream as CompilerTokenStream;
+use quote::{quote, quote_spanned};
+
+/// Docker images of IPFS daemon versions supported by this library, in ascending order.
+fn supported() -> Vec<(String, String)> {
+    let source = [
+        ("ipfs/go-ipfs", "v0.7.0"),
+        ("ipfs/go-ipfs", "v0.8.0"),
+        ("ipfs/go-ipfs", "v0.9.1"),
+        ("ipfs/go-ipfs", "v0.10.0"),
+        ("ipfs/go-ipfs", "v0.11.1"),
+        ("ipfs/go-ipfs", "v0.12.2"),
+        ("ipfs/go-ipfs", "v0.13.0"),
+        ("ipfs/kubo", "v0.14.0"),
+        ("ipfs/kubo", "v0.15.0"),
+        ("ipfs/kubo", "v0.16.0"),
+        ("ipfs/kubo", "v0.17.0"),
+    ];
+
+    source
+        .into_iter()
+        .map(|(i, t)| (i.into(), t.into()))
+        .collect()
+}
+
+/// Docker image of most recent supported IPFS daemon.
+fn current() -> (String, String) {
+    supported().into_iter().last().unwrap()
+}
+
+fn image_test_case(image_name: &str, image_tag: &str) -> proc_macro2::TokenStream {
+    quote! {
+        #[test_case::test_case(#image_name, #image_tag)]
+    }
+}
+
+fn unexpected_meta(meta: CompilerTokenStream) -> Option<CompilerTokenStream> {
+    let m2: proc_macro2::TokenStream = meta.into();
+
+    if let Some(m) = m2.into_iter().next() {
+        let result = quote_spanned! { m.span() =>
+            compile_error!("Macro does not expect any arguments.");
+        };
+
+        Some(result.into())
+    } else {
+        None
+    }
+}
+
+#[proc_macro_attribute]
+pub fn test_current_image(
+    meta: CompilerTokenStream,
+    input: CompilerTokenStream,
+) -> CompilerTokenStream {
+    if let Some(err) = unexpected_meta(meta) {
+        err
+    } else {
+        let (image_name, image_tag) = current();
+
+        let tokens = vec![image_test_case(&image_name, &image_tag), input.into()];
+
+        let result = quote! {
+            #(#tokens)*
+        };
+
+        result.into()
+    }
+}
+
+#[proc_macro_attribute]
+pub fn test_supported_images(
+    meta: CompilerTokenStream,
+    input: CompilerTokenStream,
+) -> CompilerTokenStream {
+    if let Some(err) = unexpected_meta(meta) {
+        err
+    } else {
+        let mut tokens: Vec<_> = supported()
+            .iter()
+            .map(|(image_name, image_tag)| {
+                quote! {
+                    #[test_case::test_case(#image_name, #image_tag)]
+                }
+            })
+            .collect();
+
+        tokens.push(input.into());
+
+        let result = quote! {
+            #(#tokens)*
+        };
+
+        result.into()
+    }
+}

--- a/ipfs-api/Cargo.toml
+++ b/ipfs-api/Cargo.toml
@@ -28,5 +28,19 @@ ipfs-api-backend-hyper    = { version = "0.5", path = "../ipfs-api-backend-hyper
 
 [dev-dependencies]
 actix-rt                  = "2.5"
+cfg-if                    = "1"
 futures                   = "0.3"
-tokio                     = { version = "1", features = ["rt-multi-thread", "macros"] }
+ipfs-api-versions         = { version = "0.1", path = "../ipfs-api-versions" }
+passivized_docker_engine_client = "0.0.6"
+passivized_htpasswd       = "0.0.3"
+reqwest                   = "0.11"
+tempfile                  = "3.3"
+test-case                 = "2.2"
+thiserror                 = "1.0"
+tokio                     = { version = "1", features = ["fs", "rt-multi-thread", "macros"] }
+
+# Only when testing with-hyper
+hyper                     = "0.14"
+
+# Only when testing with-hyper-tls
+hyper-tls                 = "0.5"

--- a/ipfs-api/tests/test_basic_auth.rs
+++ b/ipfs-api/tests/test_basic_auth.rs
@@ -1,0 +1,63 @@
+// Copyright 2022 rust-ipfs-api Developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+#[path = "test_support/lib.rs"]
+mod test_support;
+
+use test_support::client::{build_client, wait_for_server};
+use test_support::container::{IpfsContainer, NginxContainer};
+use test_support::images;
+use test_support::rt::run_async;
+
+use ipfs_api_versions::test_current_image;
+
+#[test_current_image]
+fn test_basic_auth(image_name: &str, image_tag: &str) {
+    run_async(run_test(image_name, image_tag));
+}
+
+async fn run_test(image_name: &str, image_tag: &str) {
+    let expected_version = images::extract_version(image_tag);
+
+    let container = IpfsContainer::new("test_basic_auth_ipfs", image_name, image_tag)
+        .await
+        .unwrap();
+
+    {
+        let api_url = format!("http://{}:5001", container.ip);
+        let client = build_client(&api_url);
+        let version = wait_for_server(&client).await.unwrap();
+
+        assert_eq!(expected_version, version.version);
+    }
+
+    let nginx = NginxContainer::new("test_basic_auth_nginx", &container.ip)
+        .await
+        .unwrap();
+
+    println!("Waiting for nginx");
+
+    nginx.wait_for().await.unwrap();
+
+    println!("Connecting to IPFS through nginx");
+
+    {
+        let api_url = format!("http://{}", nginx.ip);
+        let client = build_client(&api_url).with_credentials(&nginx.username, &nginx.password);
+        let version = wait_for_server(&client).await.unwrap();
+
+        assert_eq!(expected_version, version.version);
+    }
+
+    println!("Tearing down nginx");
+
+    nginx.teardown().await.unwrap();
+
+    println!("Tearing down ipfs");
+
+    container.teardown().await.unwrap();
+}

--- a/ipfs-api/tests/test_get_version.rs
+++ b/ipfs-api/tests/test_get_version.rs
@@ -1,0 +1,39 @@
+// Copyright 2022 rust-ipfs-api Developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+#[path = "test_support/lib.rs"]
+mod test_support;
+
+use test_support::client::{build_client, wait_for_server};
+use test_support::container::IpfsContainer;
+use test_support::images;
+use test_support::rt::run_async;
+
+use ipfs_api_versions::test_supported_images;
+
+#[test_supported_images]
+fn test_get_version(image_name: &str, image_tag: &str) {
+    run_async(run_test(image_name, image_tag));
+}
+
+async fn run_test(image_name: &str, image_tag: &str) {
+    let expected_version = images::extract_version(image_tag);
+
+    let container_name = format!("test_get_version_{}", expected_version.replace('.', "-"));
+
+    let container = IpfsContainer::new(&container_name, image_name, image_tag)
+        .await
+        .unwrap();
+
+    let api_url = format!("http://{}:5001", container.ip);
+    let client = build_client(&api_url);
+    let version = wait_for_server(&client).await.unwrap();
+
+    assert_eq!(expected_version, version.version);
+
+    container.teardown().await.unwrap();
+}

--- a/ipfs-api/tests/test_support/client.rs
+++ b/ipfs-api/tests/test_support/client.rs
@@ -1,0 +1,68 @@
+// Copyright 2022 rust-ipfs-api Developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use std::time::Duration;
+
+use ipfs_api::response::VersionResponse;
+use ipfs_api::{IpfsApi, IpfsClient, TryFromUri};
+
+#[cfg(feature = "with-hyper")]
+use hyper::client::HttpConnector;
+
+#[cfg(feature = "with-hyper-tls")]
+use hyper_tls::HttpsConnector;
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "with-actix")] {
+        pub fn build_client(api_url: &str) -> IpfsClient {
+            IpfsClient::from_str(api_url).unwrap()
+        }
+    } else if #[cfg(feature = "with-hyper-tls")] {
+        pub fn build_client(api_url: &str) -> IpfsClient<HttpsConnector<HttpConnector>> {
+            IpfsClient::from_str(api_url).unwrap()
+        }
+    } else if #[cfg(feature = "with-hyper")] {
+        pub fn build_client(api_url: &str) -> IpfsClient<HttpConnector> {
+            IpfsClient::from_str(api_url).unwrap()
+        }
+    }
+}
+
+pub async fn wait_for_server<C: IpfsApi>(client: &C) -> Result<VersionResponse, String> {
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "with-actix")] {
+            const MESSAGE: &str = "Failed to connect to host: Connection refused";
+        } else if #[cfg(feature = "with-hyper")] {
+            const MESSAGE: &str = "tcp connect error";
+        }
+    }
+
+    let mut attempts = 0;
+
+    loop {
+        tokio::time::sleep(Duration::from_secs(5)).await;
+
+        match client.version().await.map_err(|e| format!("{}", e)) {
+            Ok(v) => {
+                return Ok(v);
+            }
+            Err(msg) => {
+                println!("Not ready yet: {}", msg);
+
+                if msg.contains(MESSAGE) {
+                    attempts += 1;
+
+                    if attempts >= 4 {
+                        return Err(format!("Already tried {} times", attempts));
+                    }
+                } else {
+                    return Err(format!("Other failure: {}", msg));
+                }
+            }
+        }
+    }
+}

--- a/ipfs-api/tests/test_support/container.rs
+++ b/ipfs-api/tests/test_support/container.rs
@@ -1,0 +1,196 @@
+// Copyright 2022 rust-ipfs-api Developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use hyper::StatusCode;
+use passivized_docker_engine_client::model::MountMode::ReadOnly;
+use passivized_docker_engine_client::requests::{CreateContainerRequest, HostConfig};
+use passivized_docker_engine_client::DockerEngineClient;
+use tempfile::NamedTempFile;
+
+use super::errors::TestError;
+use super::images;
+use super::resources::{set_config_permissions, write_default_conf};
+
+pub struct IpfsContainer {
+    docker: DockerEngineClient,
+    container_id: String,
+    pub ip: String,
+}
+
+impl IpfsContainer {
+    pub async fn new(name: &str, image_name: &str, image_tag: &str) -> Result<Self, TestError> {
+        let docker = DockerEngineClient::new()?;
+
+        docker
+            .images()
+            .pull_if_not_present(image_name, image_tag)
+            .await?;
+
+        let create_request = CreateContainerRequest::default()
+            .name(name)
+            .image(format!("{}:{}", image_name, image_tag))
+            .cmd(vec!["daemon", "--migrate=true"]);
+
+        let container = docker.containers().create(create_request).await?;
+
+        docker.container(&container.id).start().await?;
+
+        let inspected = docker.container(&container.id).inspect().await?;
+
+        let ip = inspected.first_ip_address().unwrap().to_string();
+
+        let result = Self {
+            docker,
+            container_id: container.id,
+            ip,
+        };
+
+        Ok(result)
+    }
+
+    pub async fn teardown(&self) -> Result<(), TestError> {
+        self.docker.container(&self.container_id).stop().await?;
+
+        self.docker.container(&self.container_id).remove().await?;
+
+        Ok(())
+    }
+}
+
+pub struct NginxContainer {
+    /// While not used after assignment, we hold it in scope so it drops when Self drops.
+    _default_conf: NamedTempFile,
+    _htpasswd: NamedTempFile,
+    docker: DockerEngineClient,
+    container_id: String,
+    pub ip: String,
+    pub username: String,
+    pub password: String,
+}
+
+impl NginxContainer {
+    pub async fn new(name: &str, target_ip: &str) -> Result<Self, TestError> {
+        const PROXY_USERNAME: &str = "foo";
+        const PROXY_PASSWORD: &str = "bar";
+
+        let default_conf = NamedTempFile::new()?;
+        let default_conf_file = default_conf.path().to_str().unwrap();
+
+        write_default_conf(target_ip, default_conf.path()).await?;
+
+        let htpasswd_path = NamedTempFile::new()?;
+
+        {
+            let mut htpasswd = passivized_htpasswd::Htpasswd::new();
+            htpasswd.set(PROXY_USERNAME, PROXY_PASSWORD).unwrap();
+            htpasswd.write_to_path(&htpasswd_path).unwrap();
+        }
+
+        set_config_permissions(htpasswd_path.path()).unwrap();
+
+        let htpasswd_file = htpasswd_path.path().to_str().unwrap().to_string();
+
+        let docker = DockerEngineClient::new()?;
+
+        docker
+            .images()
+            .pull_if_not_present(images::nginx::IMAGE, images::nginx::TAG)
+            .await?;
+
+        let create_request = CreateContainerRequest::default()
+            .name(name)
+            .image(format!("{}:{}", images::nginx::IMAGE, images::nginx::TAG))
+            .host_config(
+                HostConfig::default()
+                    .auto_remove()
+                    .mount(
+                        default_conf_file,
+                        "/etc/nginx/conf.d/default.conf",
+                        ReadOnly,
+                    )
+                    .mount(htpasswd_file, "/secrets/htpasswd", ReadOnly),
+            );
+
+        let container = docker.containers().create(create_request).await?;
+
+        docker.container(&container.id).start().await?;
+
+        let inspected = docker.container(&container.id).inspect().await?;
+
+        let ip = inspected.first_ip_address().unwrap().to_string();
+
+        let result = Self {
+            _default_conf: default_conf,
+            _htpasswd: htpasswd_path,
+            docker,
+            container_id: container.id,
+            ip,
+            username: PROXY_USERNAME.into(),
+            password: PROXY_PASSWORD.into(),
+        };
+
+        Ok(result)
+    }
+
+    pub async fn wait_for(&self) -> Result<(), String> {
+        use std::time::Duration;
+
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "with-actix")] {
+                const MESSAGE: &str = "Failed to connect to host: Connection refused";
+            } else if #[cfg(feature = "with-hyper")] {
+                const MESSAGE: &str = "tcp connect error";
+            }
+        }
+
+        let url = format!("http://{}", self.ip);
+
+        let mut attempts = 0;
+
+        loop {
+            tokio::time::sleep(Duration::from_secs(2)).await;
+
+            let failure = match reqwest::get(&url).await {
+                Ok(response) => {
+                    if response.status() == StatusCode::UNAUTHORIZED {
+                        // Successfully connected, and because we did not pass any credentials,
+                        // we expect an Unauthorized response.
+                        None
+                    } else {
+                        Some(format!("HTTP status {}", response.status()))
+                    }
+                }
+                Err(e) => Some(format!("{:?}", e)),
+            };
+
+            match failure {
+                None => break,
+                Some(msg) => {
+                    eprintln!("Not ready yet: {}", msg);
+
+                    if msg.contains(MESSAGE) {
+                        attempts += 1;
+
+                        if attempts >= 7 {
+                            return Err(format!("Already tried {} times", attempts));
+                        }
+                    } else {
+                        return Err(format!("Other failure: {}", msg));
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub async fn teardown(&self) -> Result<(), TestError> {
+        self.docker.container(&self.container_id).stop().await?;
+
+        Ok(())
+    }
+}

--- a/ipfs-api/tests/test_support/default-template.conf
+++ b/ipfs-api/tests/test_support/default-template.conf
@@ -1,0 +1,26 @@
+# Copyright 2022 rust-ipfs-api Developers
+#
+# Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+# http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+# http://opensource.org/licenses/MIT>, at your option. This file may not be
+# copied, modified, or distributed except according to those terms.
+
+server {
+    listen 80;
+
+    location / {
+        auth_basic "Restricted";
+        auth_basic_user_file /secrets/htpasswd;
+
+        proxy_read_timeout     60;
+        proxy_connect_timeout  60;
+
+        proxy_pass          http://replaced_at_runtime:5001;
+        proxy_http_version  1.1;
+
+        proxy_set_header    Host $http_host;
+        proxy_set_header    X-Forwarded-Host $http_host;
+        proxy_set_header    X-Forwarded-Proto $scheme;
+        proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}

--- a/ipfs-api/tests/test_support/errors.rs
+++ b/ipfs-api/tests/test_support/errors.rs
@@ -1,0 +1,27 @@
+// Copyright 2022 rust-ipfs-api Developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use passivized_docker_engine_client::errors::{DecCreateError, DecUseError};
+
+#[derive(Debug, thiserror::Error)]
+pub enum TestError {
+    #[error("Docker client creation error: {0}")]
+    DockerClientCreate(#[from] DecCreateError),
+
+    #[error("Docker client error: {0}")]
+    DockerClientUse(DecUseError),
+
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+// Doesn't conform to the trait requirements of #[from]
+impl From<DecUseError> for TestError {
+    fn from(other: DecUseError) -> Self {
+        Self::DockerClientUse(other)
+    }
+}

--- a/ipfs-api/tests/test_support/images.rs
+++ b/ipfs-api/tests/test_support/images.rs
@@ -1,0 +1,18 @@
+// Copyright 2022 rust-ipfs-api Developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+pub mod nginx {
+    pub const IMAGE: &str = "nginx";
+    pub const TAG: &str = "1.23-alpine";
+}
+
+/// Extract version triple from an IPFS/Kubo Docker image tag.
+///
+/// Result should match VersionResponse::version
+pub fn extract_version(image_tag: &str) -> String {
+    image_tag.strip_prefix('v').unwrap().to_string()
+}

--- a/ipfs-api/tests/test_support/lib.rs
+++ b/ipfs-api/tests/test_support/lib.rs
@@ -1,0 +1,17 @@
+// Copyright 2022 rust-ipfs-api Developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+// Each test compiles separately, but not all tests use everything in test support.
+#![allow(dead_code)]
+
+mod resources;
+
+pub mod client;
+pub mod container;
+pub mod errors;
+pub mod images;
+pub mod rt;

--- a/ipfs-api/tests/test_support/resources.rs
+++ b/ipfs-api/tests/test_support/resources.rs
@@ -1,0 +1,63 @@
+// Copyright 2022 rust-ipfs-api Developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::test_support::errors::TestError;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+/// From a path foo/bar/qux.txt, remove foo/
+fn strip_path_prefix(path: &Path) -> PathBuf {
+    let base = path
+        .components()
+        .into_iter()
+        .next()
+        .unwrap()
+        .as_os_str()
+        .to_str()
+        .unwrap();
+
+    path.strip_prefix(base).unwrap().to_owned()
+}
+
+async fn read_default_conf_template() -> Result<String, TestError> {
+    let raw_file = PathBuf::from_str(file!()).unwrap();
+
+    let file = if raw_file.exists() {
+        raw_file
+    } else {
+        // Obviously this file exists, but the working dir might be confused by the tools running the test.
+        strip_path_prefix(&raw_file)
+    };
+
+    let absolute_file = file.canonicalize().unwrap();
+
+    let parent = absolute_file.parent().unwrap().to_owned();
+
+    let absolute = parent.canonicalize().unwrap().to_owned();
+
+    let path = absolute.join("default-template.conf");
+
+    Ok(tokio::fs::read_to_string(path).await?)
+}
+
+pub fn set_config_permissions(path: &Path) -> Result<(), std::io::Error> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let f = std::fs::File::open(path)?;
+    f.set_permissions(PermissionsExt::from_mode(0o644))
+}
+
+pub async fn write_default_conf(ip: &str, output: &Path) -> Result<(), TestError> {
+    let template = read_default_conf_template().await?;
+    let config = template.replace("replaced_at_runtime", ip);
+
+    println!("Writing {}", output.to_str().unwrap());
+
+    tokio::fs::write(output, config).await?;
+
+    Ok(())
+}

--- a/ipfs-api/tests/test_support/rt.rs
+++ b/ipfs-api/tests/test_support/rt.rs
@@ -1,0 +1,17 @@
+// Copyright 2022 rust-ipfs-api Developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use std::future::Future;
+
+/// Hyper tests can use [tokio::test] but Actix can't due to LocalSet requirement.
+pub fn run_async<F: Future>(f: F) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+
+    // Actix requires LocalSet. Hyper doesn't care.
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&rt, f);
+}


### PR DESCRIPTION
Add support for passing basic authentication on HTTP requests.

Useful for when an authenticating reverse proxy is in between the client and the IPFS HTTP api, such as Nginx configured with `auth_basic` - which this PR includes tests for.

Questions for maintainers:

1. Placement of tests

I noticed that the `ipfs_api` crate is marked deprecated, but its also not typical to put integration tests in with examples. In this case, it might make sense to do so depending on the future of `ipfs_api`. Do you prefer the tests in the current location, or in `ipfs-api-examples`?

2. Placement of basic auth struct member

Currently, `credentials` (an `Option<(String, String)>` containing username/password) is placed on the `ActixBackend` and `HyperBackend` structs, but there's also a `GlobalOptions` with comment "Options valid on any IPFS Api request" - which of these two locations (backends vs `GlobalOptions`) is the preferred place to set credentials?
