### PR TITLE
Disambiguate IpfsClient::default() when using feature with-hyper-tls

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,14 @@ jobs:
       run: cargo clippy --all-targets -- -D warnings
     - name: Build (Default)
       run: cargo build --verbose
+    - name: Build examples (Default)
+      run: cargo build --verbose --examples
+    - name: Build examples (Actix)
+      run: cargo build --verbose --examples --no-default-features --features with-actix
+    - name: Build examples (Hyper with tls)
+      run: cargo build --verbose --examples --no-default-features --features with-hyper-tls
+    - name: Build examples (Hyper with rustls)
+      run: cargo build --verbose --examples --no-default-features --features with-hyper-rustls
     - name: Run tests (Default)
       run: cargo test --verbose
     - name: Build (Actix)

--- a/ipfs-api-backend-actix/src/lib.rs
+++ b/ipfs-api-backend-actix/src/lib.rs
@@ -4,7 +4,21 @@
 // http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
-//
+
+//! Connect to an IPFS API using a client implemented with Actix.
+//!
+//! # Example
+//!
+//! ```rust
+//!  use ipfs_api_backend_actix::{IpfsApi, IpfsClient};
+//!  use ipfs_api_backend_actix::response::VersionResponse;
+//!
+//!  async fn example() -> Result<VersionResponse, ipfs_api_backend_actix::Error> {
+//!     let client = IpfsClient::default();
+//!
+//!     client.version().await
+//! }
+//! ```
 
 extern crate actix_multipart_rfc7578 as multipart;
 

--- a/ipfs-api-backend-hyper/src/backend.rs
+++ b/ipfs-api-backend-hyper/src/backend.rs
@@ -59,6 +59,15 @@ macro_rules! impl_default {
     };
 }
 
+// Because the Hyper TLS connector supports both HTTP and HTTPS,
+// if TLS is enabled, always use the TLS connector as default.
+//
+// Otherwise, compile errors will result due to ambiguity:
+//
+//   * "cannot infer type for struct `IpfsClient<_>`"
+//
+#[cfg(not(feature = "with-hyper-tls"))]
+#[cfg(not(feature = "with-hyper-rustls"))]
 impl_default!(HttpConnector);
 
 #[cfg(feature = "with-hyper-tls")]

--- a/ipfs-api-backend-hyper/src/lib.rs
+++ b/ipfs-api-backend-hyper/src/lib.rs
@@ -4,7 +4,21 @@
 // http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
-//
+
+//! Connect to an IPFS API using a client implemented with hyper.
+//!
+//! # Example
+//!
+//! ```rust
+//!  use ipfs_api_backend_hyper::{IpfsApi, IpfsClient};
+//!  use ipfs_api_backend_hyper::response::VersionResponse;
+//!
+//!  async fn example() -> Result<VersionResponse, ipfs_api_backend_hyper::Error> {
+//!     let client = IpfsClient::default();
+//!
+//!     client.version().await
+//! }
+//! ```
 
 extern crate hyper_multipart_rfc7578 as multipart;
 

--- a/ipfs-api-examples/Cargo.toml
+++ b/ipfs-api-examples/Cargo.toml
@@ -18,6 +18,8 @@ maintenance               = { status = "passively-maintained" }
 [features]
 default                   = ["with-hyper"]
 with-hyper                = ["ipfs-api-backend-hyper", "tokio/macros", "tokio/rt-multi-thread"]
+with-hyper-tls            = ["with-hyper", "ipfs-api-backend-hyper/with-hyper-tls"]
+with-hyper-rustls         = ["with-hyper", "ipfs-api-backend-hyper/with-hyper-rustls"]
 with-actix                = ["ipfs-api-backend-actix", "actix-rt"]
 
 [dependencies]

--- a/ipfs-api-examples/examples/pubsub.rs
+++ b/ipfs-api-examples/examples/pubsub.rs
@@ -14,12 +14,6 @@ use tokio_stream::wrappers::IntervalStream;
 
 static TOPIC: &str = "test";
 
-fn get_client() -> IpfsClient {
-    eprintln!("connecting to localhost:5001...");
-
-    IpfsClient::default()
-}
-
 // Creates an Ipfs client, and simultaneously publishes and reads from a pubsub
 // topic.
 //
@@ -29,7 +23,7 @@ async fn main() {
 
     eprintln!("note: ipfs must be run with pubsub enable in config");
 
-    let publish_client = get_client();
+    let publish_client = IpfsClient::default();
 
     // This block will execute a repeating function that sends
     // a message to the "test" topic.
@@ -48,11 +42,11 @@ async fn main() {
         .boxed_local()
         .fuse();
 
-    // This block will execute a future that suscribes to a topic,
+    // This block will execute a future that subscribes to a topic,
     // and reads any incoming messages.
     //
     let mut subscribe = {
-        let client = get_client();
+        let client = IpfsClient::default();
 
         client
             .pubsub_sub(TOPIC)


### PR DESCRIPTION
When the `with-hyper-tls` feature is enabled, this will fail to compile:

```
let client = IpfsClient::default()
```

It fails because there are two implementations of the `Default` trait - one which is typed `IpfsClient<HttpConnector>` and another typed `IpfsClient<HttpsConnector<HttpConnector>>` - which has the unfortunate consequence of requiring the call site to disambiguate it, even if the call site does not care which Hyper connector is in play.

I've added docstring examples which trigger this problem, and demonstrate that it's fixed in this PR.