### PR TITLE
Add example of application error enum having an ipfs_api::Error

### DIFF
--- a/ipfs-api-backend-hyper/src/backend.rs
+++ b/ipfs-api-backend-hyper/src/backend.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 rust-ipfs-api Developers
+// Copyright 2022 rust-ipfs-api Developers
 //
 // Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
 // http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
@@ -22,20 +22,20 @@ use hyper::{
 use ipfs_api_prelude::{ApiRequest, Backend, BoxStream, TryFromUri};
 use multipart::client::multipart;
 
-#[derive(Clone)]
-pub struct HyperBackend<C = HttpConnector>
-where
-    C: Connect + Clone + Send + Sync + 'static,
-{
-    base: Uri,
-    client: client::Client<C, hyper::Body>,
-}
-
 macro_rules! impl_default {
     ($http_connector:path) => {
         impl_default!($http_connector, <$http_connector>::new());
     };
     ($http_connector:path, $constructor:expr) => {
+        #[derive(Clone)]
+        pub struct HyperBackend<C = $http_connector>
+        where
+            C: Connect + Clone + Send + Sync + 'static,
+        {
+            base: Uri,
+            client: client::Client<C, hyper::Body>,
+        }
+
         impl Default for HyperBackend<$http_connector> {
             /// Creates an `IpfsClient` connected to the endpoint specified in ~/.ipfs/api.
             /// If not found, tries to connect to `localhost:5001`.

--- a/ipfs-api-examples/Cargo.toml
+++ b/ipfs-api-examples/Cargo.toml
@@ -28,6 +28,7 @@ futures                   = "0.3"
 ipfs-api-backend-actix    = { version = "0.6", path = "../ipfs-api-backend-actix", optional = true }
 ipfs-api-backend-hyper    = { version = "0.5", path = "../ipfs-api-backend-hyper", optional = true }
 tar                       = "0.4"
+thiserror                 = "1"
 tokio                     = { version = "1", features = ["time"] }
 tokio-stream              = { version = "0.1", features = ["time"] }
 tracing-subscriber        = { version = "0.3", features = ["fmt"] }

--- a/ipfs-api-examples/examples/app_error_enum.rs
+++ b/ipfs-api-examples/examples/app_error_enum.rs
@@ -1,0 +1,65 @@
+// Copyright 2022 rust-ipfs-api Developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Demonstrates how to define an application error enum that has an ipfs_api::Error as possibility.
+
+use ipfs_api_examples::ipfs_api;
+use ipfs_api_examples::ipfs_api::response::VersionResponse;
+use ipfs_api_examples::ipfs_api::{IpfsApi, IpfsClient};
+
+/// An error type that is either an IPFS client error, or some other error.
+#[derive(Debug, thiserror::Error)]
+enum ApplicationError {
+    #[error("IPFS error: {0}")]
+    Ipfs(#[from] ipfs_api::Error),
+
+    #[error("{0}")]
+    Message(String),
+}
+
+/// Similar to get_version example, except implementation is in a function called by main rather
+/// than in main itself, and the callee, use_client, returns Result with a custom error type.
+#[ipfs_api_examples::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+
+    let client = IpfsClient::default();
+
+    // Get and print version, using client directly
+    if let Err(e) = use_api(&client).await {
+        eprintln!("{:?}", e);
+    }
+
+    // Get and print version, using client by its trait IpfsApi
+    if let Err(e) = use_client(&client).await {
+        eprintln!("{:?}", e);
+    }
+}
+
+fn print_version(version: VersionResponse) -> Result<(), ApplicationError> {
+    if version.version.starts_with("0.0") {
+        Err(ApplicationError::Message(format!(
+            "Version {} is very old",
+            version.version
+        )))
+    } else {
+        println!("Version: {}", version.version);
+        Ok(())
+    }
+}
+
+async fn use_api<A: IpfsApi<Error = ipfs_api::Error>>(client: &A) -> Result<(), ApplicationError> {
+    let version = client.version().await?;
+
+    print_version(version)
+}
+
+async fn use_client(client: &IpfsClient) -> Result<(), ApplicationError> {
+    let version = client.version().await?;
+
+    print_version(version)
+}


### PR DESCRIPTION
The other examples unwrap or otherwise deal with an `Err` result in their `main` function.

This one defines its own error enumeration, with `ipfs_api::Error` as one of the possibilities, and shows how to make that work with rust's `?` automatic error conversion, in two scenarios.

Scenario 1, where the function has an `IpfsClient` variable.

Scenario 2, where the function accepts a parameter that implements the `IpfsApi` type. In this scenario, the generic must be constrained to use the implementation's error type - that is, the type on `Backend::Error` - otherwise the compiler will complain that it doesn't know what `Backend<A>::Error` is.

It may seem that this should be obvious looking at this example, but the IDE could not resolve any methods of an `IpfsClient` variable, which lead to using an `&IpfsApi` instead. However, without further constraining `IpfsApi::Error` (which is `Backend::Error`), it was confusing to figure out how to do it.
