### PR TITLE
Upgrade tokio-util from 0.6 to 0.7

### DIFF
--- a/ipfs-api-prelude/Cargo.toml
+++ b/ipfs-api-prelude/Cargo.toml
@@ -34,7 +34,7 @@ serde_json                = "1"
 serde_urlencoded          = "0.7"
 thiserror                 = "1"
 tokio                     = "1"
-tokio-util                = { version = "0.6", features = ["codec"] }
+tokio-util                = { version = "0.7", features = ["codec"] }
 tracing                   = "0.1"
 typed-builder             = { version = "0.10", optional = true }
 walkdir                   = "2.3"


### PR DESCRIPTION
Another dependency, `hyper-multipart-rfc7578`, depends on 0.7.

After this change the build uses a single version of tokio-util.