### PR TITLE
Switch from `use … as IpfsClient` to type aliases for clearer API docs.

### DIFF
--- a/ipfs-api-backend-actix/src/lib.rs
+++ b/ipfs-api-backend-actix/src/lib.rs
@@ -25,7 +25,8 @@ extern crate actix_multipart_rfc7578 as multipart;
 mod backend;
 mod error;
 
-pub use crate::{backend::ActixBackend as IpfsClient, error::Error};
+pub type IpfsClient = ActixBackend;
+pub use crate::{backend::ActixBackend, error::Error};
 pub use ipfs_api_prelude::{
     request::{self, KeyType, Logger, LoggingLevel, ObjectTemplate},
     response, ApiError, BackendWithGlobalOptions, GlobalOptions, IpfsApi, TryFromUri,

--- a/ipfs-api-backend-hyper/src/lib.rs
+++ b/ipfs-api-backend-hyper/src/lib.rs
@@ -25,7 +25,8 @@ extern crate hyper_multipart_rfc7578 as multipart;
 mod backend;
 mod error;
 
-pub use crate::{backend::HyperBackend as IpfsClient, error::Error};
+pub type IpfsClient = HyperBackend;
+pub use crate::{backend::HyperBackend, error::Error};
 pub use ipfs_api_prelude::{
     request::{self, KeyType, Logger, LoggingLevel, ObjectTemplate},
     response, ApiError, BackendWithGlobalOptions, GlobalOptions, IpfsApi, TryFromUri,


### PR DESCRIPTION
I find the generated API docs for `use path::Foo as Bar` to be confusing compared to type aliases.

# Current docs from `master` branch

Currently in master, the identifier `ipfs_api_backend_hyper::IpfsClient` is [defined as](https://github.com/ferristseng/rust-ipfs-api/blob/master/ipfs-api-backend-hyper/src/lib.rs#L28):

```
pub use crate::{backend::HyperBackend as IpfsClient, error::Error};
```

The rendered API docs look like this:

![Screenshot 2023-05-23 11 09 19](https://github.com/ferristseng/rust-ipfs-api/assets/4369700/c3dbb1fb-331c-4882-beb2-5eec13532280)

What is the relationship of `IpfsClient` to  `HyperBackend`?

I believe the root problem here is actually a `rustdoc` problem, but this PR uses type aliases to work around the ambiguity.

# With type aliases (this PR) in `HyperBackend`

By introducing type aliases first of all the alias is documented explicitly:

![Screenshot 2023-05-23 11 19 39](https://github.com/ferristseng/rust-ipfs-api/assets/4369700/b48af012-fe88-45a1-9945-f0fe6e4b45a3)

-then when clicking through to the definition of `HyperBackend` the API is unambiguous:

![Screenshot 2023-05-23 11 19 26](https://github.com/ferristseng/rust-ipfs-api/assets/4369700/0bce113f-fcd8-42a7-8631-f0340b37dd84)

# With type aliases (this PR) in `ActixBackend`

The equivalent for `ActixBackend` has this type alias:

![Screenshot 2023-05-23 11 31 12](https://github.com/ferristseng/rust-ipfs-api/assets/4369700/e1b9d51c-4b45-4212-919a-d851e4c0ed4c)

-and this underlying backend API:

![Screenshot 2023-05-23 11 31 00](https://github.com/ferristseng/rust-ipfs-api/assets/4369700/87d21553-77ba-43e2-b7ee-8be5277edd8a)
