### PR TITLE
Require Debug trait for implementations of Backend::Error attribute of Backend trait

### DIFF
--- a/ipfs-api-prelude/src/backend.rs
+++ b/ipfs-api-prelude/src/backend.rs
@@ -20,7 +20,7 @@ use http::{
     StatusCode,
 };
 use serde::Deserialize;
-use std::fmt::Display;
+use std::fmt::{Debug, Display};
 use tokio_util::codec::{Decoder, FramedRead};
 
 cfg_if::cfg_if! {
@@ -46,9 +46,9 @@ pub trait Backend {
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "with-send-sync")] {
-            type Error: Display + From<ApiError> + From<crate::Error> + Send + 'static;
+            type Error: Display + Debug + From<ApiError> + From<crate::Error> + Send + 'static;
         } else {
-            type Error: Display + From<ApiError> + From<crate::Error> + 'static;
+            type Error: Display + Debug + From<ApiError> + From<crate::Error> + 'static;
         }
     }
 

--- a/ipfs-api/tests/test_backend.rs
+++ b/ipfs-api/tests/test_backend.rs
@@ -1,0 +1,8 @@
+use ipfs_api::IpfsApi;
+
+// If this compiles, the test has passed, as unwrap() requires the Debug trait.
+#[allow(unused)]
+async fn test_use_client<C: IpfsApi>(client: &C) {
+    // Validate that all variants of the Backend trait's Error type (Backend::Error) implement the Debug trait.
+    client.version().await.unwrap();
+}


### PR DESCRIPTION
Allows test and experimental code to call unwrap() on IpfsApi methods when a concrete implementation of IpfsClient is not known in the current scope.

All of the existing implementations in the library already support the Debug trait, but it can't be used in some contexts without this change.