### PR TITLE
Upgrade workspace to Cargo resolver 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 members = [
   "ipfs-api",


### PR DESCRIPTION
The crates imply resolver v2 based on their use of edition 2021, but the workspace defaults to v1. Make them match on v2.

Background:

https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html

https://nickb.dev/blog/cargo-workspace-and-the-feature-unification-pitfall/

Also resolves this warning:
```
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
```