### PR TITLE
feat: add `id_with_options` method

### DIFF
--- a/ipfs-api-prelude/src/api.rs
+++ b/ipfs-api-prelude/src/api.rs
@@ -1603,7 +1603,41 @@ pub trait IpfsApi: Backend {
     /// ```
     ///
     async fn id(&self, peer: Option<&str>) -> Result<response::IdResponse, Self::Error> {
-        self.request(request::Id { peer }, None).await
+        self.request(
+            request::Id {
+                peer,
+                format: None,
+                peerid_base: None,
+            },
+            None,
+        )
+        .await
+    }
+
+    /// Returns information about a peer.
+    ///
+    /// If `peer` is `None`, returns information about you.
+    ///
+    /// ```no_run
+    /// use ipfs_api::{IpfsApi, IpfsClient};
+    ///
+    /// let client = IpfsClient::default();
+    /// #[cfg(feature = "with-builder")]
+    /// let req = ipfs_api::request::Id::builder()
+    ///     .peer("QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM")
+    ///     .build();
+    /// #[cfg(not(feature = "with-builder"))]
+    /// let req = ipfs_api::request::Id {
+    ///     peer: "QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM",
+    ///     .. Default::default()
+    /// };
+    /// let res = client.id_with_options(req);
+    ///
+    async fn id_with_options(
+        &self,
+        options: request::Id<'_>,
+    ) -> Result<response::IdResponse, Self::Error> {
+        self.request(options, None).await
     }
 
     /// Create a new keypair.

--- a/ipfs-api-prelude/src/api.rs
+++ b/ipfs-api-prelude/src/api.rs
@@ -1606,7 +1606,7 @@ pub trait IpfsApi: Backend {
         self.request(
             request::Id {
                 peer,
-                format: (),
+                format: None,
                 peerid_base: None,
             },
             None,

--- a/ipfs-api-prelude/src/api.rs
+++ b/ipfs-api-prelude/src/api.rs
@@ -1606,7 +1606,7 @@ pub trait IpfsApi: Backend {
         self.request(
             request::Id {
                 peer,
-                format: None,
+                format: (),
                 peerid_base: None,
             },
             None,

--- a/ipfs-api-prelude/src/request/id.rs
+++ b/ipfs-api-prelude/src/request/id.rs
@@ -18,9 +18,10 @@ pub struct Id<'a> {
     #[cfg_attr(feature = "with-builder", builder(default, setter(strip_option)))]
     pub peer: Option<&'a str>,
 
-    /// Optional output format.
-    #[cfg_attr(feature = "with-builder", builder(default, setter(strip_option)))]
-    pub format: Option<&'a str>,
+    /// Ignored by go-ipfs in it's REST API. Always returns in JSON. Retained for compatibility.
+    #[serde(skip)]
+    #[cfg_attr(feature = "with-builder", builder(default))]
+    pub format: (),
 
     /// Encoding used for peer IDs: Can either be a multibase encoded CID or a base58btc encoded multihash. Takes {b58mh|base36|k|base32|b...}. Default: b58mh.
     #[cfg_attr(feature = "with-builder", builder(default, setter(strip_option)))]

--- a/ipfs-api-prelude/src/request/id.rs
+++ b/ipfs-api-prelude/src/request/id.rs
@@ -9,10 +9,22 @@
 use crate::request::ApiRequest;
 use serde::Serialize;
 
-#[derive(Serialize)]
+#[cfg_attr(feature = "with-builder", derive(TypedBuilder))]
+#[derive(Default, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct Id<'a> {
+    /// Peer.ID of node to look up.
     #[serde(rename = "arg")]
+    #[cfg_attr(feature = "with-builder", builder(default, setter(strip_option)))]
     pub peer: Option<&'a str>,
+
+    /// Optional output format.
+    #[cfg_attr(feature = "with-builder", builder(default, setter(strip_option)))]
+    pub format: Option<&'a str>,
+
+    /// Encoding used for peer IDs: Can either be a multibase encoded CID or a base58btc encoded multihash. Takes {b58mh|base36|k|base32|b...}. Default: b58mh.
+    #[cfg_attr(feature = "with-builder", builder(default, setter(strip_option)))]
+    pub peerid_base: Option<&'a str>,
 }
 
 impl<'a> ApiRequest for Id<'a> {

--- a/ipfs-api-prelude/src/request/id.rs
+++ b/ipfs-api-prelude/src/request/id.rs
@@ -19,6 +19,7 @@ pub struct Id<'a> {
     pub peer: Option<&'a str>,
 
     /// Ignored by go-ipfs in it's REST API. Always returns in JSON. Retained for compatibility.
+    #[serde(skip)]
     #[cfg_attr(feature = "with-builder", builder(default, setter(strip_option)))]
     pub format: Option<IdFormat>,
 

--- a/ipfs-api-prelude/src/request/id.rs
+++ b/ipfs-api-prelude/src/request/id.rs
@@ -19,9 +19,8 @@ pub struct Id<'a> {
     pub peer: Option<&'a str>,
 
     /// Ignored by go-ipfs in it's REST API. Always returns in JSON. Retained for compatibility.
-    #[serde(skip)]
-    #[cfg_attr(feature = "with-builder", builder(default))]
-    pub format: (),
+    #[cfg_attr(feature = "with-builder", builder(default, setter(strip_option)))]
+    pub format: Option<IdFormat>,
 
     /// Encoding used for peer IDs: Can either be a multibase encoded CID or a base58btc encoded multihash. Takes {b58mh|base36|k|base32|b...}. Default: b58mh.
     #[cfg_attr(feature = "with-builder", builder(default, setter(strip_option)))]
@@ -31,3 +30,5 @@ pub struct Id<'a> {
 impl<'a> ApiRequest for Id<'a> {
     const PATH: &'static str = "/id";
 }
+
+pub enum IdFormat {}


### PR DESCRIPTION
Kubo permits the use of `peerid-base` as a parameter when making a call to `/api/v0/id`. This crate should too.

In my tests, Kubo doesn't seem to respect the `format` parameter. It always returns JSON.

In this patch, I'm retaining it for compatibility with the spec, but disabling the ability to construct it.