### PR TITLE
Update FilesCP arguments

### DIFF
--- a/ipfs-api-prelude/src/request/files.rs
+++ b/ipfs-api-prelude/src/request/files.rs
@@ -17,7 +17,9 @@ pub struct FilesCp<'a> {
     #[serde(rename = "arg")]
     pub dest: &'a str,
 
-    pub flush: Option<bool>,
+    pub force: Option<bool>,
+
+    pub parents: Option<bool>,
 }
 
 impl<'a> ApiRequest for FilesCp<'a> {


### PR DESCRIPTION
Include the new arguments 'parents' and 'force' as documented on https://docs.ipfs.tech/reference/kubo/rpc/#api-v0-files-cp